### PR TITLE
:sparkles: Add strings to the template

### DIFF
--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -53,11 +53,12 @@ pub mod {} {{
 
 #[account]
 #[bolt_account(component_id = "{}")]
-#[derive(Copy)]
 pub struct {} {{
     pub x: i64,
     pub y: i64,
     pub z: i64,
+    #[max_len(20)]
+    pub description: String,
 }}
 "#,
             anchor_cli::rust_template::get_or_create_program_id(name),
@@ -104,6 +105,8 @@ pub struct Position {{
     pub x: i64,
     pub y: i64,
     pub z: i64,
+    #[max_len(20)]
+    pub description: String,
 }}
 "#,
             anchor_cli::rust_template::get_or_create_program_id(name),


### PR DESCRIPTION
# :sparkles: Add strings to the template

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Hold | Feature/Bug | No | - |

## Problem

- The component template was adding the Copy traits, which is not implemented for Strings

## Solution

- Removed the Copy trait and added an example with String in the generated template