### PR TITLE
:sparkles: Add a working ecs example on project init

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -147,6 +147,8 @@ jobs:
 
       - name: Install the Bolt CLI, create a project and run tests
         run: |
+          rustc --version
+          cargo --version
           cargo install --path cli --force --locked
           bolt init test-project --force
           sleep 5

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -144,6 +144,12 @@ jobs:
           npm i -g @coral-xyz/anchor-cli@${{ env.anchor_version }} ts-mocha typescript
           anchor test
 
+      - name: Install the Bolt CLI, create a project and run tests
+        run: |
+          cargo install --path cli --force --locked
+          bolt init test-project --force
+          cd test-project && bolt test
+
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -43,7 +43,7 @@ jobs:
           yarn --frozen-lockfile --network-concurrency 2
 
       - name: install rust
-        uses: dtolnay/rust-toolchain@1.73.0
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
 
@@ -147,8 +147,8 @@ jobs:
 
       - name: Install the Bolt CLI, create a project and run tests
         run: |
-          rustc --version
-          cargo --version
+          export PATH="/home/runner/.local/share/solana/install/active_release/bin:$PATH"
+          cargo add solana-readonly-account
           cargo install --path cli --force --locked
           bolt init test-project --force
           cd test-project && bolt test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 env:
-  solana_version: v1.18.0
+  solana_version: v1.17.0
   anchor_version: 0.29.0
 
 jobs:
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: cache solana cli
         id: cache-solana
         with:
@@ -22,7 +22,7 @@ jobs:
             ~/.local/share/solana/
           key: solana-${{ runner.os }}-v0000-${{ env.solana_version }}
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -47,7 +47,11 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Cache rust
+        uses: Swatinem/rust-cache@v2
+
       - name: install solana
+        if: steps.cache-solana.outputs.cache-hit != 'true'
         run: |
           sh -c "$(curl -sSfL https://release.solana.com/${{ env.solana_version }}/install)"
           export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
@@ -58,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cache rust
         uses: Swatinem/rust-cache@v2
       - name: Run fmt
@@ -70,14 +74,14 @@ jobs:
     needs: install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
       - name: Cache node dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -90,10 +94,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: install rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Cache rust
+        uses: Swatinem/rust-cache@v2
+
+      - uses: actions/checkout@v4
 
       - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -107,7 +119,7 @@ jobs:
           export PATH="/home/runner/.local/share/solana/install/active_release/bin:$PATH"
           yarn --frozen-lockfile
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: cache solana cli
         id: cache-solana
         with:
@@ -143,8 +155,6 @@ jobs:
 
       - name: Install the Bolt CLI, create a project and run tests
         run: |
-          rustc --version
-          cargo --version
           export PATH="/home/runner/.local/share/solana/install/active_release/bin:$PATH"
           cargo install --path cli --force --locked
           bolt init test-project --force

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 env:
-  solana_version: v1.17.0
+  solana_version: v1.18.0
   anchor_version: 0.29.0
 
 jobs:
@@ -153,12 +153,11 @@ jobs:
           npm i -g @coral-xyz/anchor-cli@${{ env.anchor_version }} ts-mocha typescript
           anchor test
 
-      - name: Install the Bolt CLI, create a project and run tests
+      - name: Install the Bolt CLI and create a new project
         run: |
           export PATH="/home/runner/.local/share/solana/install/active_release/bin:$PATH"
           cargo install --path cli --force --locked
           bolt init test-project --force
-          cd test-project && bolt test
 
       - uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Install the Bolt CLI, create a project and run tests
         run: |
           export PATH="/home/runner/.local/share/solana/install/active_release/bin:$PATH"
-          cargo add solana-readonly-account
+          cargo add --package bolt-cli solana-readonly-account
           cargo install --path cli --force --locked
           bolt init test-project --force
           cd test-project && bolt test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -149,7 +149,8 @@ jobs:
         run: |
           cargo install --path cli --force --locked
           bolt init test-project --force
-          cd test-project && anchor test
+          sleep 5
+          cd test-project && bolt test
 
       - uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -153,11 +153,12 @@ jobs:
           npm i -g @coral-xyz/anchor-cli@${{ env.anchor_version }} ts-mocha typescript
           anchor test
 
-      - name: Install the Bolt CLI and create a new project
+      - name: Install the Bolt CLI and create & build a new project
         run: |
           export PATH="/home/runner/.local/share/solana/install/active_release/bin:$PATH"
           cargo install --path cli --force --locked
           bolt init test-project --force
+          cd test-project && bolt build
 
       - uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -42,7 +42,8 @@ jobs:
           export PATH="/home/runner/.local/share/solana/install/active_release/bin:$PATH"
           yarn --frozen-lockfile --network-concurrency 2
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: install rust
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
 
@@ -148,7 +149,7 @@ jobs:
         run: |
           cargo install --path cli --force --locked
           bolt init test-project --force
-          cd test-project && bolt test
+          cd test-project && anchor test
 
       - uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -43,7 +43,7 @@ jobs:
           yarn --frozen-lockfile --network-concurrency 2
 
       - name: install rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.73.0
         with:
           toolchain: stable
 
@@ -151,7 +151,6 @@ jobs:
           cargo --version
           cargo install --path cli --force --locked
           bolt init test-project --force
-          sleep 5
           cd test-project && bolt test
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,14 +4,14 @@ on:
   pull_request:
 
 env:
-  solana_version: v1.17.0
+  solana_version: v1.18.0
   anchor_version: 0.29.0
 
 jobs:
   install:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/cache@v3
         name: cache solana cli
@@ -43,15 +43,11 @@ jobs:
           yarn --frozen-lockfile --network-concurrency 2
 
       - name: install rust
-        uses: dtolnay/rust-toolchain@1.75.0
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
 
-      - name: Cache rust
-        uses: Swatinem/rust-cache@v2
-
       - name: install solana
-        if: steps.cache-solana.outputs.cache-hit != 'true'
         run: |
           sh -c "$(curl -sSfL https://release.solana.com/${{ env.solana_version }}/install)"
           export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
@@ -150,7 +146,6 @@ jobs:
           rustc --version
           cargo --version
           export PATH="/home/runner/.local/share/solana/install/active_release/bin:$PATH"
-          cargo add --package bolt-cli solana-readonly-account
           cargo install --path cli --force --locked
           bolt init test-project --force
           cd test-project && bolt test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -43,7 +43,7 @@ jobs:
           yarn --frozen-lockfile --network-concurrency 2
 
       - name: install rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.75.0
         with:
           toolchain: stable
 
@@ -147,6 +147,8 @@ jobs:
 
       - name: Install the Bolt CLI, create a project and run tests
         run: |
+          rustc --version
+          cargo --version
           export PATH="/home/runner/.local/share/solana/install/active_release/bin:$PATH"
           cargo add --package bolt-cli solana-readonly-account
           cargo install --path cli --force --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,6 +950,7 @@ dependencies = [
  "anyhow",
  "clap 4.4.11",
  "heck 0.4.1",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -968,6 +969,7 @@ version = "0.1.0"
 name = "bolt-lang"
 version = "0.0.1"
 dependencies = [
+ "ahash 0.8.6",
  "anchor-lang 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bolt-attribute-bolt-account",
  "bolt-attribute-bolt-component",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-access-control"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
+source = "git+https://github.com/coral-xyz/anchor.git#169264d730ffeae16c12a33c0c353b7d3a461532"
 dependencies = [
  "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
  "proc-macro2",
@@ -150,7 +150,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-account"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
+source = "git+https://github.com/coral-xyz/anchor.git#169264d730ffeae16c12a33c0c353b7d3a461532"
 dependencies = [
  "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
  "bs58 0.5.0",
@@ -173,7 +173,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-constant"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
+source = "git+https://github.com/coral-xyz/anchor.git#169264d730ffeae16c12a33c0c353b7d3a461532"
 dependencies = [
  "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
  "quote",
@@ -194,7 +194,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-error"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
+source = "git+https://github.com/coral-xyz/anchor.git#169264d730ffeae16c12a33c0c353b7d3a461532"
 dependencies = [
  "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
  "quote",
@@ -216,7 +216,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-event"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
+source = "git+https://github.com/coral-xyz/anchor.git#169264d730ffeae16c12a33c0c353b7d3a461532"
 dependencies = [
  "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
  "proc-macro2",
@@ -238,7 +238,7 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-program"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
+source = "git+https://github.com/coral-xyz/anchor.git#169264d730ffeae16c12a33c0c353b7d3a461532"
 dependencies = [
  "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
  "quote",
@@ -248,7 +248,7 @@ dependencies = [
 [[package]]
 name = "anchor-cli"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
+source = "git+https://github.com/coral-xyz/anchor.git#169264d730ffeae16c12a33c0c353b7d3a461532"
 dependencies = [
  "anchor-client",
  "anchor-lang 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
@@ -285,7 +285,7 @@ dependencies = [
 [[package]]
 name = "anchor-client"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
+source = "git+https://github.com/coral-xyz/anchor.git#169264d730ffeae16c12a33c0c353b7d3a461532"
 dependencies = [
  "anchor-lang 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
  "anyhow",
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "anchor-derive-accounts"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
+source = "git+https://github.com/coral-xyz/anchor.git#169264d730ffeae16c12a33c0c353b7d3a461532"
 dependencies = [
  "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
  "quote",
@@ -337,10 +337,10 @@ dependencies = [
 [[package]]
 name = "anchor-derive-serde"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
+source = "git+https://github.com/coral-xyz/anchor.git#169264d730ffeae16c12a33c0c353b7d3a461532"
 dependencies = [
  "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
- "borsh-derive-internal 0.9.3",
+ "borsh-derive-internal 0.10.3",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -360,7 +360,7 @@ dependencies = [
 [[package]]
 name = "anchor-derive-space"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
+source = "git+https://github.com/coral-xyz/anchor.git#169264d730ffeae16c12a33c0c353b7d3a461532"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -395,7 +395,7 @@ dependencies = [
 [[package]]
 name = "anchor-lang"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
+source = "git+https://github.com/coral-xyz/anchor.git#169264d730ffeae16c12a33c0c353b7d3a461532"
 dependencies = [
  "ahash 0.8.6",
  "anchor-attribute-access-control 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
@@ -410,7 +410,7 @@ dependencies = [
  "arrayref",
  "base64 0.21.5",
  "bincode",
- "borsh 0.9.3",
+ "borsh 0.10.3",
  "bytemuck",
  "getrandom 0.2.10",
  "solana-program",
@@ -438,7 +438,7 @@ dependencies = [
 [[package]]
 name = "anchor-syn"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
+source = "git+https://github.com/coral-xyz/anchor.git#169264d730ffeae16c12a33c0c353b7d3a461532"
 dependencies = [
  "anyhow",
  "bs58 0.5.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-access-control"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0#fc9fd6d24b9be84abb2f40e47ed3faf7b11864ae"
+source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
 dependencies = [
- "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0)",
+ "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -150,9 +150,9 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-account"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0#fc9fd6d24b9be84abb2f40e47ed3faf7b11864ae"
+source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
 dependencies = [
- "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0)",
+ "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
  "bs58 0.5.0",
  "proc-macro2",
  "quote",
@@ -173,9 +173,9 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-constant"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0#fc9fd6d24b9be84abb2f40e47ed3faf7b11864ae"
+source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
 dependencies = [
- "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0)",
+ "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
  "quote",
  "syn 1.0.109",
 ]
@@ -194,9 +194,9 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-error"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0#fc9fd6d24b9be84abb2f40e47ed3faf7b11864ae"
+source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
 dependencies = [
- "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0)",
+ "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
  "quote",
  "syn 1.0.109",
 ]
@@ -216,9 +216,9 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-event"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0#fc9fd6d24b9be84abb2f40e47ed3faf7b11864ae"
+source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
 dependencies = [
- "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0)",
+ "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -238,9 +238,9 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-program"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0#fc9fd6d24b9be84abb2f40e47ed3faf7b11864ae"
+source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
 dependencies = [
- "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0)",
+ "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
  "quote",
  "syn 1.0.109",
 ]
@@ -248,13 +248,13 @@ dependencies = [
 [[package]]
 name = "anchor-cli"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0#fc9fd6d24b9be84abb2f40e47ed3faf7b11864ae"
+source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
 dependencies = [
  "anchor-client",
- "anchor-lang 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0)",
- "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0)",
+ "anchor-lang 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
+ "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
  "anyhow",
- "base64 0.13.1",
+ "base64 0.21.5",
  "bincode",
  "cargo_toml",
  "chrono",
@@ -285,9 +285,9 @@ dependencies = [
 [[package]]
 name = "anchor-client"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0#fc9fd6d24b9be84abb2f40e47ed3faf7b11864ae"
+source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
 dependencies = [
- "anchor-lang 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0)",
+ "anchor-lang 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
  "anyhow",
  "futures",
  "regex",
@@ -314,9 +314,9 @@ dependencies = [
 [[package]]
 name = "anchor-derive-accounts"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0#fc9fd6d24b9be84abb2f40e47ed3faf7b11864ae"
+source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
 dependencies = [
- "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0)",
+ "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
  "quote",
  "syn 1.0.109",
 ]
@@ -337,10 +337,10 @@ dependencies = [
 [[package]]
 name = "anchor-derive-serde"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0#fc9fd6d24b9be84abb2f40e47ed3faf7b11864ae"
+source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
 dependencies = [
- "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0)",
- "borsh-derive-internal 0.10.3",
+ "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
+ "borsh-derive-internal 0.9.3",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -360,7 +360,7 @@ dependencies = [
 [[package]]
 name = "anchor-derive-space"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0#fc9fd6d24b9be84abb2f40e47ed3faf7b11864ae"
+source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -395,21 +395,22 @@ dependencies = [
 [[package]]
 name = "anchor-lang"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0#fc9fd6d24b9be84abb2f40e47ed3faf7b11864ae"
+source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
 dependencies = [
- "anchor-attribute-access-control 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0)",
- "anchor-attribute-account 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0)",
- "anchor-attribute-constant 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0)",
- "anchor-attribute-error 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0)",
- "anchor-attribute-event 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0)",
- "anchor-attribute-program 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0)",
- "anchor-derive-accounts 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0)",
- "anchor-derive-serde 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0)",
- "anchor-derive-space 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0)",
+ "ahash 0.8.6",
+ "anchor-attribute-access-control 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
+ "anchor-attribute-account 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
+ "anchor-attribute-constant 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
+ "anchor-attribute-error 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
+ "anchor-attribute-event 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
+ "anchor-attribute-program 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
+ "anchor-derive-accounts 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
+ "anchor-derive-serde 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
+ "anchor-derive-space 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
  "arrayref",
- "base64 0.13.1",
+ "base64 0.21.5",
  "bincode",
- "borsh 0.10.3",
+ "borsh 0.9.3",
  "bytemuck",
  "getrandom 0.2.10",
  "solana-program",
@@ -437,7 +438,7 @@ dependencies = [
 [[package]]
 name = "anchor-syn"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=v0.29.0#fc9fd6d24b9be84abb2f40e47ed3faf7b11864ae"
+source = "git+https://github.com/coral-xyz/anchor.git#ef3b1493484e9d193f3cb270753484c30f75bcd8"
 dependencies = [
  "anyhow",
  "bs58 0.5.0",
@@ -947,10 +948,11 @@ name = "bolt-cli"
 version = "0.0.1"
 dependencies = [
  "anchor-cli",
+ "anchor-client",
  "anyhow",
  "clap 4.4.11",
  "heck 0.4.1",
- "syn 2.0.38",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4686,9 +4688,9 @@ dependencies = [
 
 [[package]]
 name = "solang-parser"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb9fa2fa2fa6837be8a2495486ff92e3ffe68a99b6eeba288e139efdd842457"
+checksum = "c425ce1c59f4b154717592f0bdf4715c3a1d55058883622d3157e1f0908a5b26"
 dependencies = [
  "itertools 0.11.0",
  "lalrpop",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/bin/main.rs"
 dev = []
 
 [dependencies]
-anchor-cli = { git = "https://github.com/coral-xyz/anchor.git"}
+anchor-cli = { git = "https://github.com/coral-xyz/anchor.git" }
 anchor-client = { git = "https://github.com/coral-xyz/anchor.git" }
 anyhow = "1.0.32"
 heck = "0.4.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,7 +16,9 @@ path = "src/bin/main.rs"
 dev = []
 
 [dependencies]
-anchor-cli = { git = "https://github.com/coral-xyz/anchor.git", rev = "v0.29.0" }
+anchor-cli = { git = "https://github.com/coral-xyz/anchor.git"}
+anchor-client = { git = "https://github.com/coral-xyz/anchor.git" }
 anyhow = "1.0.32"
 heck = "0.4.0"
 clap = { version = "4.2.4", features = ["derive"] }
+syn = { version = "1.0.60", features = ["full", "extra-traits"] }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -276,14 +276,14 @@ fn init(
             if solidity {
                 test.write_all(anchor_cli::solidity_template::jest(&project_name).as_bytes())?;
             } else {
-                test.write_all(anchor_cli::rust_template::jest(&project_name).as_bytes())?;
+                test.write_all(rust_template::jest(&project_name).as_bytes())?;
             }
         } else {
             let mut test = File::create(format!("tests/{}.js", &project_name))?;
             if solidity {
                 test.write_all(anchor_cli::solidity_template::mocha(&project_name).as_bytes())?;
             } else {
-                test.write_all(anchor_cli::rust_template::mocha(&project_name).as_bytes())?;
+                test.write_all(rust_template::mocha(&project_name).as_bytes())?;
             }
         }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -35,17 +35,16 @@ pub struct InitCommand {
 
 #[derive(Debug, Parser)]
 pub struct ComponentCommand {
-    #[clap(short, long, help = "Name of the component")]
     pub name: String,
 }
 
 #[derive(Debug, Parser)]
 pub struct SystemCommand {
-    #[clap(short, long, help = "Name of the system")]
     pub name: String,
 }
 
 #[derive(Debug, Parser)]
+#[clap(version = VERSION)]
 pub struct Opts {
     #[clap(flatten)]
     pub cfg_override: ConfigOverride,
@@ -135,7 +134,7 @@ fn init(
         fs::create_dir(&project_name)?;
     }
     std::env::set_current_dir(&project_name)?;
-    fs::create_dir("app")?;
+    fs::create_dir_all("app")?;
 
     let mut cfg = Config::default();
     if jest {
@@ -239,7 +238,7 @@ fn init(
     // Initialize .prettierignore file
     fs::write(
         ".prettierignore",
-        anchor_cli::rust_template::prettier_ignore(),
+        rust_template::prettier_ignore(),
     )?;
 
     // Remove the default programs if `--force` is passed
@@ -256,7 +255,7 @@ fn init(
         )?;
     }
 
-    // Build the program.
+    //Build the program.
     if solidity {
         anchor_cli::solidity_template::create_program(&project_name)?;
     } else {
@@ -266,9 +265,9 @@ fn init(
     }
 
     // Build the test suite.
-    fs::create_dir("tests")?;
+    fs::create_dir_all("tests")?;
     // Build the migrations directory.
-    fs::create_dir("migrations")?;
+    fs::create_dir_all("migrations")?;
 
     if javascript {
         // Build javascript config

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -236,26 +236,23 @@ fn init(
     fs::write(".gitignore", rust_template::git_ignore())?;
 
     // Initialize .prettierignore file
-    fs::write(
-        ".prettierignore",
-        rust_template::prettier_ignore(),
-    )?;
+    fs::write(".prettierignore", rust_template::prettier_ignore())?;
 
     // Remove the default programs if `--force` is passed
     if force {
-        fs::remove_dir_all(
-            std::env::current_dir()?
-                .join(if solidity { "solidity" } else { "programs" })
-                .join(&project_name),
-        )?;
-        fs::remove_dir_all(
-            std::env::current_dir()?
-                .join("programs-ecs")
-                .join(&project_name),
-        )?;
+        let programs_path = std::env::current_dir()?
+            .join(if solidity { "solidity" } else { "programs" })
+            .join(&project_name);
+        fs::create_dir_all(&programs_path)?;
+        fs::remove_dir_all(&programs_path)?;
+        let programs_ecs_path = std::env::current_dir()?
+            .join("programs-ecs")
+            .join(&project_name);
+        fs::create_dir_all(&programs_ecs_path)?;
+        fs::remove_dir_all(&programs_ecs_path)?;
     }
 
-    //Build the program.
+    // Build the program.
     if solidity {
         anchor_cli::solidity_template::create_program(&project_name)?;
     } else {

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -1,5 +1,5 @@
-use crate::VERSION;
 use crate::ANCHOR_VERSION;
+use crate::VERSION;
 use anchor_cli::Files;
 use anyhow::Result;
 use heck::{ToKebabCase, ToSnakeCase, ToUpperCamelCase};
@@ -104,7 +104,6 @@ pub struct Position {{
     pub x: i64,
     pub y: i64,
     pub z: i64,
-    #[max_len(20)]
     pub description: String,
 }}
 "#,
@@ -260,8 +259,8 @@ describe("{}", () => {{
 
   it("InitializeNewWorld", async () => {{
         const registry = await Registry.fromAccountAddress(provider.connection, registryPda);
-        worldId = new BN(registry.worlds);
-        worldPda = FindWorldPda(new BN(worldId))
+        worldId = new anchor.BN(registry.worlds);
+        worldPda = FindWorldPda(new anchor.BN(worldId))
         const initializeWorldIx = createInitializeNewWorldInstruction(
             {{
                 world: worldPda,

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -228,6 +228,88 @@ pub fn ts_package_json(jest: bool) -> String {
     }
 }
 
+pub fn mocha(name: &str) -> String {
+    format!(
+        r#"const anchor = require("@coral-xyz/anchor");
+const boltSdk = require("bolt-sdk");
+const {{
+    createInitializeNewWorldInstruction,
+    FindWorldPda,
+    FindWorldRegistryPda,
+    Registry,
+    World
+}} = boltSdk;
+
+describe("{}", () => {{
+  // Configure the client to use the local cluster.
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+
+  it("InitializeNewWorld", async () => {{
+      const registry = await Registry.fromAccountAddress(provider.connection, registryPda);
+      worldId = new anchor.BN(registry.worlds);
+      worldPda = FindWorldPda(new anchor.BN(worldId))
+      const initializeWorldIx = createInitializeNewWorldInstruction(
+          {{
+              world: worldPda,
+              registry: registryPda,
+              payer: provider.wallet.publicKey,
+          }});
+
+      const tx = new anchor.web3.Transaction().add(initializeWorldIx);
+      const txSign = await provider.sendAndConfirm(tx);
+      console.log(`Initialized a new world (ID=${{worldId}}). Initialization signature: ${{txSign}}`);
+    }});
+  }});
+}});
+"#,
+        name,
+    )
+}
+
+pub fn jest(name: &str) -> String {
+    format!(
+        r#"const anchor = require("@coral-xyz/anchor");
+const boltSdk = require("bolt-sdk");
+const {{
+    createInitializeNewWorldInstruction,
+    FindWorldPda,
+    FindWorldRegistryPda,
+    Registry,
+    World
+}} = boltSdk;
+
+describe("{}", () => {{
+  // Configure the client to use the local cluster.
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+
+  // Constants used to test the program.
+  const registryPda = FindWorldRegistryPda();
+  let worldId: anchor.BN;
+  let worldPda: PublicKey;
+
+  it("InitializeNewWorld", async () => {{
+      const registry = await Registry.fromAccountAddress(provider.connection, registryPda);
+      worldId = new anchor.BN(registry.worlds);
+      worldPda = FindWorldPda(new anchor.BN(worldId))
+      const initializeWorldIx = createInitializeNewWorldInstruction(
+          {{
+              world: worldPda,
+              registry: registryPda,
+              payer: provider.wallet.publicKey,
+          }});
+
+      const tx = new anchor.web3.Transaction().add(initializeWorldIx);
+      const txSign = await provider.sendAndConfirm(tx);
+      console.log(`Initialized a new world (ID=${{worldId}}). Initialization signature: ${{txSign}}`);
+    }});
+  }});
+"#,
+        name,
+    )
+}
+
 pub fn ts_mocha(name: &str) -> String {
     format!(
         r#"import * as anchor from "@coral-xyz/anchor";

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -1,4 +1,5 @@
 use crate::VERSION;
+use crate::ANCHOR_VERSION;
 use anchor_cli::Files;
 use anyhow::Result;
 use heck::{ToKebabCase, ToSnakeCase, ToUpperCamelCase};
@@ -6,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 /// Create a component from the given name.
 pub fn create_component(name: &str) -> Result<()> {
-    let program_path = Path::new("programs").join(name);
+    let program_path = Path::new("programs-ecs/components").join(name);
     let common_files = vec![
         (
             PathBuf::from("Cargo.toml".to_string()),
@@ -22,7 +23,7 @@ pub fn create_component(name: &str) -> Result<()> {
 
 /// Create a system from the given name.
 pub(crate) fn create_system(name: &str) -> Result<()> {
-    let program_path = Path::new("programs").join(name);
+    let program_path = Path::new("programs-ecs/systems").join(name);
     let common_files = vec![
         (
             PathBuf::from("Cargo.toml".to_string()),
@@ -36,7 +37,7 @@ pub(crate) fn create_system(name: &str) -> Result<()> {
     anchor_cli::create_files(&[common_files, template_files].concat())
 }
 
-/// Create a program with a single `lib.rs` file.
+/// Create a component which holds position data.
 fn create_component_template_simple(name: &str, program_path: &Path) -> Files {
     vec![(
         program_path.join("src").join("lib.rs"),
@@ -70,7 +71,7 @@ pub struct {} {{
     )]
 }
 
-/// Create a program with a single `lib.rs` file.
+/// Create a system which operates on a Position component.
 fn create_system_template_simple(name: &str, program_path: &Path) -> Files {
     vec![(
         program_path.join("src").join("lib.rs"),
@@ -85,10 +86,8 @@ pub mod {} {{
     use super::*;
 
     pub fn execute(ctx: Context<Component>, args: Vec<u8>) -> Result<Position> {{
-
         let mut position = Position::from_account_info(&ctx.accounts.position)?;
         position.x += 1;
-
         Ok(position)
     }}
 }}
@@ -118,7 +117,9 @@ pub struct Position {{
 const fn workspace_manifest() -> &'static str {
     r#"[workspace]
 members = [
-    "programs/*"
+    "programs/*",
+    "programs-ecs/components/*",
+    "programs-ecs/systems/*"
 ]
 resolver = "2"
 
@@ -131,6 +132,155 @@ opt-level = 3
 incremental = false
 codegen-units = 1
 "#
+}
+
+pub fn package_json(jest: bool) -> String {
+    if jest {
+        format!(
+            r#"{{
+        "scripts": {{
+            "lint:fix": "prettier */*.js \"*/**/*{{.js,.ts}}\" -w",
+            "lint": "prettier */*.js \"*/**/*{{.js,.ts}}\" --check"
+        }},
+        "dependencies": {{
+            "@coral-xyz/anchor": "^{VERSION}"
+        }},
+        "devDependencies": {{
+            "jest": "^29.0.3",
+            "prettier": "^2.6.2"
+        }}
+    }}
+    "#
+        )
+    } else {
+        format!(
+            r#"{{
+    "scripts": {{
+        "lint:fix": "prettier */*.js \"*/**/*{{.js,.ts}}\" -w",
+        "lint": "prettier */*.js \"*/**/*{{.js,.ts}}\" --check"
+    }},
+    "dependencies": {{
+        "@coral-xyz/anchor": "^{VERSION}"
+    }},
+    "devDependencies": {{
+        "chai": "^4.3.4",
+        "mocha": "^9.0.3",
+        "prettier": "^2.6.2"
+    }}
+}}
+"#
+        )
+    }
+}
+
+pub fn ts_package_json(jest: bool) -> String {
+    if jest {
+        format!(
+            r#"{{
+        "scripts": {{
+            "lint:fix": "prettier */*.js \"*/**/*{{.js,.ts}}\" -w",
+            "lint": "prettier */*.js \"*/**/*{{.js,.ts}}\" --check"
+        }},
+        "dependencies": {{
+            "@coral-xyz/anchor": "^{ANCHOR_VERSION}"
+        }},
+        "devDependencies": {{
+            "@types/bn.js": "^5.1.0",
+            "@types/jest": "^29.0.3",
+            "jest": "^29.0.3",
+            "prettier": "^2.6.2",
+            "ts-jest": "^29.0.2",
+            "typescript": "^4.3.5",
+            "@metaplex-foundation/beet": "^0.7.1",
+            "@metaplex-foundation/beet-solana": "^0.4.0",
+            "bolt-sdk": "latest"
+        }}
+    }}
+    "#
+        )
+    } else {
+        format!(
+            r#"{{
+    "scripts": {{
+        "lint:fix": "prettier */*.js \"*/**/*{{.js,.ts}}\" -w",
+        "lint": "prettier */*.js \"*/**/*{{.js,.ts}}\" --check"
+    }},
+    "dependencies": {{
+        "@coral-xyz/anchor": "^{ANCHOR_VERSION}"
+    }},
+    "devDependencies": {{
+        "chai": "^4.3.4",
+        "mocha": "^9.0.3",
+        "ts-mocha": "^10.0.0",
+        "@types/bn.js": "^5.1.0",
+        "@types/chai": "^4.3.0",
+        "@types/mocha": "^9.0.0",
+        "typescript": "^4.3.5",
+        "prettier": "^2.6.2",
+        "@metaplex-foundation/beet": "^0.7.1",
+        "@metaplex-foundation/beet-solana": "^0.4.0",
+        "bolt-sdk": "latest"
+    }}
+}}
+"#
+        )
+    }
+}
+
+pub fn ts_mocha(name: &str) -> String {
+    format!(
+        r#"import * as anchor from "@coral-xyz/anchor";
+import {{ Program }} from "@coral-xyz/anchor";
+import {{ PublicKey }} from "@solana/web3.js";
+import {{ {} }} from "../target/types/{}";
+import {{
+    createInitializeNewWorldInstruction,
+    FindWorldPda,
+    FindWorldRegistryPda,
+    FindEntityPda,
+    Registry,
+    World,
+    createAddEntityInstruction,
+    createInitializeComponentInstruction,
+    FindComponentPda, createApplyInstruction
+}} from "bolt-sdk"
+
+describe("{}", () => {{
+  // Configure the client to use the local cluster.
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+
+  // Constants used to test the program.
+  const registryPda = FindWorldRegistryPda();
+  let worldId: anchor.BN;
+  let worldPda: PublicKey;
+  let entityPda: PublicKey;
+
+  const program = anchor.workspace.{} as Program<{}>;
+
+  it("InitializeNewWorld", async () => {{
+        const registry = await Registry.fromAccountAddress(provider.connection, registryPda);
+        worldId = new BN(registry.worlds);
+        worldPda = FindWorldPda(new BN(worldId))
+        const initializeWorldIx = createInitializeNewWorldInstruction(
+            {{
+                world: worldPda,
+                registry: registryPda,
+                payer: provider.wallet.publicKey,
+            }});
+
+        const tx = new anchor.web3.Transaction().add(initializeWorldIx);
+        const txSign = await provider.sendAndConfirm(tx);
+        console.log(`Initialized a new world (ID=${{worldId}}). Initialization signature: ${{txSign}}`);
+    }});
+}});
+"#,
+        name.to_upper_camel_case(),
+        name.to_snake_case(),
+        name,
+        name.to_upper_camel_case(),
+        name.to_upper_camel_case(),
+    )
 }
 
 fn cargo_toml(name: &str) -> String {
@@ -166,5 +316,17 @@ anchor-lang = "{3}"
 fn xargo_toml() -> &'static str {
     r#"[target.bpfel-unknown-unknown.dependencies.std]
 features = []
+"#
+}
+pub fn git_ignore() -> &'static str {
+    r#"
+.anchor
+.bolt
+.DS_Store
+target
+**/*.rs.bk
+node_modules
+test-ledger
+.yarn
 "#
 }

--- a/crates/bolt-lang/Cargo.toml
+++ b/crates/bolt-lang/Cargo.toml
@@ -21,3 +21,6 @@ bolt-system = { path = "../../programs/bolt-system", features = ["cpi"], version
 # Other dependencies
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+# TODO: Remove once https://github.com/solana-labs/solana/issues/33504 is resolved.
+ahash = "=0.8.6"


### PR DESCRIPTION
# Add a working ecs example on project init

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Hold | Feature  | No | #5  |

## Problem

Complex to setup the ECS and interaction with the World program

## Solution

- On Init, create a minimal working example with one Component and one System
- Anchor.toml specify the accounts that needs to be cloned in the local validator 

### Other improvements

- Fix `--version` command
- Enable the `--force` flag to init over existing folders
- Remove `-n` from the `component` and `systems` command. E.g.: creating a component now can be done with `bolt component new-component`
- Add tests for the CLI. Added a workflow to install it, create a new-project and run the tests of the new project

## Dependencies

Depends on https://github.com/coral-xyz/anchor/pull/2785 for defining workspace members

```yaml
[workspace]
members = [
    "programs/*",
    "programs-ecs/components/*",
    "programs-ecs/systems/*"
]
```

## Issues

Closes #5 