### PR TITLE
:sparkles: Dynamic types resolver

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -4,17 +4,17 @@
 seeds = true
 skip-lint = false
 
+[programs.devnet]
+world = "WorLD15A7CrDwLcLy4fRqtaTb9fbd8o8iqiEMUDse2n"
+
 [programs.localnet]
 bolt-component = "CmP2djJgABZ4cRokm4ndxuq6LerqpNHLBsaUv2XKEJua"
 bolt-system = "7X4EFsDJ5aYTcEjKzJ94rD8FRKgQeXC89fkpeTS4KaqP"
 position = "Fn1JzzEdyb55fsyduWS94mYHizGhJZuhvjX6DVvrmGbQ"
-velocity = "CbHEFbSQdRN4Wnoby9r16umnJ1zWbULBHg4yqzGQonU1"
 system-apply-velocity = "6LHhFVwif6N9Po3jHtSmMVtPjF6zRfL3xMosSzcrQAS8"
 system-fly = "HT2YawJjkNmqWcLNfPAMvNsLdWwPvvvbKA5bpMw4eUpq"
 system-simple-movement = "FSa6qoJXFBR3a7ThQkTAMrC15p6NkchPEjBdd4n6dXxA"
-world = "WorLD15A7CrDwLcLy4fRqtaTb9fbd8o8iqiEMUDse2n"
-
-[programs.devnet]
+velocity = "CbHEFbSQdRN4Wnoby9r16umnJ1zWbULBHg4yqzGQonU1"
 world = "WorLD15A7CrDwLcLy4fRqtaTb9fbd8o8iqiEMUDse2n"
 
 [registry]
@@ -24,17 +24,8 @@ url = "https://api.apr.dev"
 cluster = "localnet"
 wallet = "./tests/fixtures/provider.json"
 
+[workspace]
+members = ["programs/bolt-component", "programs/bolt-system", "programs/world", "examples/component-position", "examples/component-velocity", "examples/system-apply-velocity", "examples/system-fly", "examples/system-simple-movement"]
+
 [scripts]
 test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/bolt.ts"
-
-[workspace]
-members = [
-    "programs/bolt-component",
-    "programs/bolt-system",
-    "programs/world",
-    "examples/component-position",
-    "examples/component-velocity",
-    "examples/system-apply-velocity",
-    "examples/system-fly",
-    "examples/system-simple-movement",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,6 +970,7 @@ version = "0.1.0"
 dependencies = [
  "anchor-cli",
  "anchor-client",
+ "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git)",
  "anyhow",
  "clap 4.4.11",
  "heck 0.4.1",
@@ -1030,6 +1031,14 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bolt-helpers-system-template",
+]
+
+[[package]]
+name = "bolt-types"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bolt-lang",
 ]
 
 [[package]]
@@ -5068,6 +5077,7 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bolt-lang",
+ "bolt-types",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,6 +974,7 @@ dependencies = [
  "anyhow",
  "clap 4.4.11",
  "heck 0.4.1",
+ "serde_json",
  "syn 1.0.109",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,6 +25,7 @@ anchor-cli = { git = "https://github.com/coral-xyz/anchor.git" }
 anchor-client = { git = "https://github.com/coral-xyz/anchor.git" }
 anchor-syn = { git = "https://github.com/coral-xyz/anchor.git" }
 anyhow = { workspace = true }
+serde_json = { workspace = true }
 heck = { workspace = true }
 clap = { workspace = true }
 syn = { workspace = true, features = ["full", "extra-traits"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,6 +23,7 @@ dev = []
 [dependencies]
 anchor-cli = { git = "https://github.com/coral-xyz/anchor.git" }
 anchor-client = { git = "https://github.com/coral-xyz/anchor.git" }
+anchor-syn = { git = "https://github.com/coral-xyz/anchor.git" }
 anyhow = { workspace = true }
 heck = { workspace = true }
 clap = { workspace = true }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -738,9 +738,12 @@ fn fetch_idl_for_component(component_id: &str, url: &str) -> Result<String> {
         Ok(idl_string)
     } else {
         let error_message = String::from_utf8(output.stderr)
-            .unwrap_or(String::from(format!("Error trying to dynamically generate the type \
+            .unwrap_or(format!(
+                "Error trying to dynamically generate the type \
             for component {}, unable to fetch the idl. \nEnsure that the idl is available. Specify \
-            the appropriate cluster using the --provider.cluster option", component_id)))
+            the appropriate cluster using the --provider.cluster option",
+                component_id
+            ))
             .to_string();
         Err(anyhow!("Command failed with error: {}", error_message))
     }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -673,7 +673,7 @@ fn process_program_path(
     let file = File::open(program_path.join("src").join("lib.rs"))?;
     let lines = io::BufReader::new(file).lines();
     let mut contains_dynamic_components = false;
-    for line in lines.flatten() {
+    for line in lines.map_while(Result::ok) {
         if let Some(component_id) = extract_component_id(&line) {
             let file_path = PathBuf::from(format!("{}/component_{}.rs", types_path, component_id));
             if !file_path.exists() {
@@ -764,7 +764,6 @@ fn generate_component_type_file(
 
 fn append_component_to_lib_rs(lib_rs_path: &Path, component_id: &str) -> Result<()> {
     let mut file = OpenOptions::new()
-        .write(true)
         .create(true)
         .append(true)
         .open(lib_rs_path)?;

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -533,7 +533,6 @@ pub fn component_type_import(component_id: &str) -> String {
     format!(
         r#"#[allow(non_snake_case)]
 mod component_{0};
-#[allow(non_snake_case)]
 pub use component_{0}::*;
 "#,
         component_id,

--- a/crates/bolt-lang/attribute/component-deserialize/src/lib.rs
+++ b/crates/bolt-lang/attribute/component-deserialize/src/lib.rs
@@ -18,7 +18,8 @@ pub fn component_deserialize(_attr: TokenStream, item: TokenStream) -> TokenStre
     let mut input = parse_macro_input!(item as DeriveInput);
 
     // Add the AnchorDeserialize and AnchorSerialize derives to the struct
-    let additional_derives: Attribute = syn::parse_quote! { #[derive(anchor_lang::AnchorDeserialize, anchor_lang::AnchorSerialize)] };
+    let additional_derives: Attribute =
+        syn::parse_quote! { #[derive(bolt_lang::AnchorDeserialize, bolt_lang::AnchorSerialize)] };
     input.attrs.push(additional_derives);
 
     add_bolt_metadata(&mut input);
@@ -32,26 +33,26 @@ pub fn component_deserialize(_attr: TokenStream, item: TokenStream) -> TokenStre
 
         #[automatically_derived]
         impl bolt_lang::ComponentDeserialize for #name{
-            fn from_account_info(account: &anchor_lang::prelude::AccountInfo) -> anchor_lang::Result<#name> {
+            fn from_account_info(account: &bolt_lang::AccountInfo) -> bolt_lang::Result<#name> {
                 #name::try_deserialize_unchecked(&mut &*(*account.data.borrow()).as_ref()).map_err(Into::into)
             }
         }
 
         #[automatically_derived]
-        impl anchor_lang::AccountDeserialize for #name {
-            fn try_deserialize(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
+        impl bolt_lang::AccountDeserialize for #name {
+            fn try_deserialize(buf: &mut &[u8]) -> bolt_lang::Result<Self> {
                 Self::try_deserialize_unchecked(buf)
             }
 
-            fn try_deserialize_unchecked(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
+            fn try_deserialize_unchecked(buf: &mut &[u8]) -> bolt_lang::Result<Self> {
                 let mut data: &[u8] = &buf[8..];
-                anchor_lang::AnchorDeserialize::deserialize(&mut data)
-                    .map_err(|_| anchor_lang::error::ErrorCode::AccountDidNotDeserialize.into())
+                bolt_lang::AnchorDeserialize::deserialize(&mut data)
+                    .map_err(|_| bolt_lang::AccountDidNotDeserializeErrorCode.into())
             }
         }
 
         #[automatically_derived]
-        impl AccountSerialize for #name {
+        impl bolt_lang::AccountSerialize for #name {
             fn try_serialize<W>(&self, _writer: &mut W) -> Result<()> {
                 Ok(())
             }

--- a/crates/bolt-lang/src/lib.rs
+++ b/crates/bolt-lang/src/lib.rs
@@ -1,4 +1,8 @@
+pub use anchor_lang::error::ErrorCode::AccountDidNotDeserialize as AccountDidNotDeserializeErrorCode;
 pub use anchor_lang::prelude::*;
+pub use anchor_lang::{
+    AccountDeserialize, AccountSerialize, AnchorDeserialize, AnchorSerialize, Result,
+};
 
 pub use bolt_attribute_bolt_component::component;
 pub use bolt_attribute_bolt_component_deserialize::component_deserialize;

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "bolt-types"
+version = "0.1.0"
+description = "Autogenerate types for the bolt language"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "bolt_types"
+
+[dependencies]
+bolt-lang = { path = "../bolt-lang" }
+anchor-lang = "0.29.0"

--- a/crates/types/src/component_Fn1JzzEdyb55fsyduWS94mYHizGhJZuhvjX6DVvrmGbQ.rs
+++ b/crates/types/src/component_Fn1JzzEdyb55fsyduWS94mYHizGhJZuhvjX6DVvrmGbQ.rs
@@ -1,0 +1,11 @@
+use bolt_lang::*;
+
+#[component_deserialize]
+#[derive(Clone, Copy)]
+pub struct ComponentFn1JzzEdyb55fsyduWS94mYHizGhJZuhvjX6DVvrmGbQ {
+    pub x: i64,
+    pub y: i64,
+    pub z: i64,
+}
+
+pub use ComponentFn1JzzEdyb55fsyduWS94mYHizGhJZuhvjX6DVvrmGbQ as Position;

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -1,4 +1,3 @@
 #[allow(non_snake_case)]
 mod component_Fn1JzzEdyb55fsyduWS94mYHizGhJZuhvjX6DVvrmGbQ;
-#[allow(non_snake_case)]
 pub use component_Fn1JzzEdyb55fsyduWS94mYHizGhJZuhvjX6DVvrmGbQ::*;

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -1,0 +1,4 @@
+#[allow(non_snake_case)]
+mod component_Fn1JzzEdyb55fsyduWS94mYHizGhJZuhvjX6DVvrmGbQ;
+#[allow(non_snake_case)]
+pub use component_Fn1JzzEdyb55fsyduWS94mYHizGhJZuhvjX6DVvrmGbQ::*;

--- a/examples/system-simple-movement/Cargo.toml
+++ b/examples/system-simple-movement/Cargo.toml
@@ -23,4 +23,5 @@ idl-build = ["anchor-lang/idl-build"]
 [dependencies]
 anchor-lang = { workspace = true }
 bolt-lang = { path = "../../crates/bolt-lang" }
+bolt-types = { version = "0.1.0", path = "../../crates/types" }
 serde = { version = "*", features = ["derive"] }

--- a/examples/system-simple-movement/src/lib.rs
+++ b/examples/system-simple-movement/src/lib.rs
@@ -18,13 +18,6 @@ pub mod system_simple_movement {
         ctx.accounts.position.x += dx;
         ctx.accounts.position.y += dy;
 
-        let _p = Position {
-            x: 1,
-            y: 2,
-            z: 3,
-            bolt_metadata: BoltMetadata::default(),
-        };
-
         Ok(ctx.accounts)
     }
 

--- a/examples/system-simple-movement/src/lib.rs
+++ b/examples/system-simple-movement/src/lib.rs
@@ -18,21 +18,20 @@ pub mod system_simple_movement {
         ctx.accounts.position.x += dx;
         ctx.accounts.position.y += dy;
 
+        let _p = Position {
+            x: 1,
+            y: 2,
+            z: 3,
+            bolt_metadata: BoltMetadata::default(),
+        };
+
         Ok(ctx.accounts)
     }
 
     #[system_input]
     pub struct Components {
-        #[component_id(address = "Fn1JzzEdyb55fsyduWS94mYHizGhJZuhvjX6DVvrmGbQ")]
+        #[component_id("Fn1JzzEdyb55fsyduWS94mYHizGhJZuhvjX6DVvrmGbQ")]
         pub position: Position,
-    }
-
-    #[component_deserialize]
-    #[derive(Clone)]
-    pub struct Position {
-        pub x: i64,
-        pub y: i64,
-        pub z: i64,
     }
 
     // Define the structs to deserialize the arguments


### PR DESCRIPTION
# Dynamic Components Resolver

| Status | Type     | ⚠️ Core Change | Issue |
|:------:|:--------:|:---------------:|:-----:|
| Ready  | Feature  | Yes             | #23   |

## Motivation

Composability on Solana is currently limited by the fact that typically crates must be available in order to interact with a program. Although Rust crates can be generated automatically if the IDL is published, this process is usually time-consuming and error-prone, as the crates could become outdated. Furthermore, the ECS pattern offers a way to structure logic in a very decoupled way, where common data structures (components) can be reused within or outside a project. This also allows anyone to write or propose logic (system) very easily. Therefore, having a simple way to use components/accounts in a new program is essential to promote composability and reuse.

## Solution

Introduce a built-in mechanism in Bolt to automatically generate Rust types for the components, using the IDL published on-chain. Automatically build the types when needed in a system.

### Specification

- Systems can specify within the struct, marked with `#[system_input]`, the bundle of input components.
- Components can use types that are dynamically generated, using the IDL retrieved from the component ID, via the `component_id` macro.

```rust
use bolt_lang::*;

declare_id!("FSa6qoJXFBR3a7ThQkTAMrC15p6NkchPEjBdd4n6dXxA");

#[system]
pub mod system_simple_movement {

    pub fn execute(ctx: Context<Components>, args_p: Vec<u8>) -> Result<Components> {
        ctx.accounts.position.x += 1;
        Ok(ctx.accounts)
    }

    #[system_input]
    pub struct Components {
        #[component_id("Fn1JzzEdyb55fsyduWS94mYHizGhJZuhvjX6DVvrmGbQ")]
        pub position: Position,
    }
}
```

### Generation

- The `bolt build` includes a pre-step that automatically parses all systems, identifies the missing types, and autogenerates the crates.
- Running `bolt build` will use the default cluster (as specified in the Anchor.toml) to retrieve the components IDL, parse it and generate the rust code.
- Running `bolt build --provider.cluster devnet` will use the specified cluster to retrieve the IDL.
- Once types are generated, the crates will be available under crates/types. The crate dependency is automatically added to the systems that need it.

<img width="548" alt="Screenshot 2024-03-08 at 15 50 32" src="https://github.com/magicblock-labs/bolt/assets/12031208/6b392863-9fbe-4f7d-8e31-b4e296e86a4b">


- Use `bolt build --rebuild-types` to force regeneration of the types (in case the IDL is updated on-chain).

<img width="758" alt="Screenshot 2024-03-08 at 15 49 51" src="https://github.com/magicblock-labs/bolt/assets/12031208/18af4791-fc79-424d-91a4-5c8a9f2db66c">

- Autogenerated types can be used to operate on the component and define the system logic.

<img width="783" alt="Screenshot 2024-03-08 at 15 53 38" src="https://github.com/magicblock-labs/bolt/assets/12031208/295de37b-f762-4207-972c-a9b92eb9bd52">

## Issues

Closes #23 