### PR TITLE
:sparkles: Upgrade to latest anchor version, supporting the new IDL standard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-access-control"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=e212105#e21210538d0415674c5c474ec36b8dca066ea62e"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19#d9a9f193947ec869e60eab58453f1791fff06576"
 dependencies = [
- "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=e212105)",
+ "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -150,9 +150,9 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-account"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=e212105#e21210538d0415674c5c474ec36b8dca066ea62e"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19#d9a9f193947ec869e60eab58453f1791fff06576"
 dependencies = [
- "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=e212105)",
+ "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "bs58 0.5.0",
  "proc-macro2",
  "quote",
@@ -173,9 +173,9 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-constant"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=e212105#e21210538d0415674c5c474ec36b8dca066ea62e"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19#d9a9f193947ec869e60eab58453f1791fff06576"
 dependencies = [
- "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=e212105)",
+ "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "quote",
  "syn 1.0.109",
 ]
@@ -194,9 +194,9 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-error"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=e212105#e21210538d0415674c5c474ec36b8dca066ea62e"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19#d9a9f193947ec869e60eab58453f1791fff06576"
 dependencies = [
- "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=e212105)",
+ "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "quote",
  "syn 1.0.109",
 ]
@@ -216,9 +216,9 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-event"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=e212105#e21210538d0415674c5c474ec36b8dca066ea62e"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19#d9a9f193947ec869e60eab58453f1791fff06576"
 dependencies = [
- "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=e212105)",
+ "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -238,9 +238,9 @@ dependencies = [
 [[package]]
 name = "anchor-attribute-program"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=e212105#e21210538d0415674c5c474ec36b8dca066ea62e"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19#d9a9f193947ec869e60eab58453f1791fff06576"
 dependencies = [
- "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=e212105)",
+ "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "quote",
  "syn 1.0.109",
 ]
@@ -248,11 +248,11 @@ dependencies = [
 [[package]]
 name = "anchor-cli"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=e212105#e21210538d0415674c5c474ec36b8dca066ea62e"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19#d9a9f193947ec869e60eab58453f1791fff06576"
 dependencies = [
  "anchor-client",
- "anchor-lang 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=e212105)",
- "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=e212105)",
+ "anchor-idl",
+ "anchor-lang 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "anyhow",
  "base64 0.21.5",
  "bincode",
@@ -285,9 +285,9 @@ dependencies = [
 [[package]]
 name = "anchor-client"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=e212105#e21210538d0415674c5c474ec36b8dca066ea62e"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19#d9a9f193947ec869e60eab58453f1791fff06576"
 dependencies = [
- "anchor-lang 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=e212105)",
+ "anchor-lang 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "anyhow",
  "futures",
  "regex",
@@ -314,9 +314,9 @@ dependencies = [
 [[package]]
 name = "anchor-derive-accounts"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=e212105#e21210538d0415674c5c474ec36b8dca066ea62e"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19#d9a9f193947ec869e60eab58453f1791fff06576"
 dependencies = [
- "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=e212105)",
+ "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "quote",
  "syn 1.0.109",
 ]
@@ -337,9 +337,9 @@ dependencies = [
 [[package]]
 name = "anchor-derive-serde"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=e212105#e21210538d0415674c5c474ec36b8dca066ea62e"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19#d9a9f193947ec869e60eab58453f1791fff06576"
 dependencies = [
- "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=e212105)",
+ "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "borsh-derive-internal 0.9.3",
  "proc-macro2",
  "quote",
@@ -360,11 +360,23 @@ dependencies = [
 [[package]]
 name = "anchor-derive-space"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=e212105#e21210538d0415674c5c474ec36b8dca066ea62e"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19#d9a9f193947ec869e60eab58453f1791fff06576"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-idl"
+version = "0.29.0"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19#d9a9f193947ec869e60eab58453f1791fff06576"
+dependencies = [
+ "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
+ "anyhow",
+ "regex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -396,18 +408,18 @@ dependencies = [
 [[package]]
 name = "anchor-lang"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=e212105#e21210538d0415674c5c474ec36b8dca066ea62e"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19#d9a9f193947ec869e60eab58453f1791fff06576"
 dependencies = [
  "ahash 0.8.6",
- "anchor-attribute-access-control 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=e212105)",
- "anchor-attribute-account 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=e212105)",
- "anchor-attribute-constant 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=e212105)",
- "anchor-attribute-error 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=e212105)",
- "anchor-attribute-event 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=e212105)",
- "anchor-attribute-program 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=e212105)",
- "anchor-derive-accounts 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=e212105)",
- "anchor-derive-serde 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=e212105)",
- "anchor-derive-space 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=e212105)",
+ "anchor-attribute-access-control 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
+ "anchor-attribute-account 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
+ "anchor-attribute-constant 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
+ "anchor-attribute-error 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
+ "anchor-attribute-event 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
+ "anchor-attribute-program 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
+ "anchor-derive-accounts 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
+ "anchor-derive-serde 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
+ "anchor-derive-space 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "arrayref",
  "base64 0.21.5",
  "bincode",
@@ -453,7 +465,7 @@ dependencies = [
 [[package]]
 name = "anchor-syn"
 version = "0.29.0"
-source = "git+https://github.com/coral-xyz/anchor.git?rev=e212105#e21210538d0415674c5c474ec36b8dca066ea62e"
+source = "git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19#d9a9f193947ec869e60eab58453f1791fff06576"
 dependencies = [
  "anyhow",
  "bs58 0.5.0",
@@ -993,7 +1005,7 @@ version = "0.1.1"
 dependencies = [
  "anchor-cli",
  "anchor-client",
- "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=e212105)",
+ "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "anyhow",
  "clap 4.4.11",
  "heck 0.4.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,7 +394,6 @@ dependencies = [
  "anchor-derive-accounts 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anchor-derive-serde 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anchor-derive-space 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anchor-syn 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrayref",
  "base64 0.13.1",
  "bincode",
@@ -420,6 +419,7 @@ dependencies = [
  "anchor-derive-accounts 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "anchor-derive-serde 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "anchor-derive-space 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
+ "anchor-syn 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "arrayref",
  "base64 0.21.5",
  "bincode",
@@ -428,20 +428,6 @@ dependencies = [
  "getrandom 0.2.10",
  "solana-program",
  "thiserror",
-]
-
-[[package]]
-name = "anchor-spl"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4fd6e43b2ca6220d2ef1641539e678bfc31b6cc393cf892b373b5997b6a39a"
-dependencies = [
- "anchor-lang 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mpl-token-metadata",
- "solana-program",
- "spl-associated-token-account",
- "spl-token",
- "spl-token-2022",
 ]
 
 [[package]]
@@ -469,6 +455,7 @@ source = "git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19#d9a9f193947ec8
 dependencies = [
  "anyhow",
  "bs58 0.5.0",
+ "cargo_toml",
  "heck 0.3.3",
  "proc-macro2",
  "quote",
@@ -1017,7 +1004,7 @@ dependencies = [
 name = "bolt-component"
 version = "0.1.1"
 dependencies = [
- "anchor-lang 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-lang 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "bolt-system",
 ]
 
@@ -1048,7 +1035,7 @@ name = "bolt-lang"
 version = "0.1.1"
 dependencies = [
  "ahash 0.8.6",
- "anchor-lang 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-lang 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "bolt-attribute-bolt-component",
  "bolt-attribute-bolt-component-deserialize",
  "bolt-attribute-bolt-component-id",
@@ -1066,7 +1053,7 @@ dependencies = [
 name = "bolt-system"
 version = "0.1.1"
 dependencies = [
- "anchor-lang 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-lang 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "bolt-helpers-system-template",
 ]
 
@@ -2749,19 +2736,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mpl-token-metadata"
-version = "3.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba8ee05284d79b367ae8966d558e1a305a781fc80c9df51f37775169117ba64f"
-dependencies = [
- "borsh 0.9.3",
- "num-derive 0.3.3",
- "num-traits",
- "solana-program",
- "thiserror",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3204,7 +3178,7 @@ dependencies = [
 name = "position"
 version = "0.1.1"
 dependencies = [
- "anchor-lang 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-lang 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "bolt-lang",
 ]
 
@@ -5085,8 +5059,7 @@ dependencies = [
 name = "system-apply-velocity"
 version = "0.1.1"
 dependencies = [
- "anchor-lang 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "anchor-spl",
+ "anchor-lang 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "bolt-lang",
  "position",
  "velocity",
@@ -5117,7 +5090,7 @@ dependencies = [
 name = "system-fly"
 version = "0.1.1"
 dependencies = [
- "anchor-lang 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-lang 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "bolt-lang",
  "position",
 ]
@@ -5126,7 +5099,7 @@ dependencies = [
 name = "system-simple-movement"
 version = "0.1.1"
 dependencies = [
- "anchor-lang 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-lang 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "bolt-lang",
  "bolt-types",
  "serde",
@@ -5622,7 +5595,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 name = "velocity"
 version = "0.1.1"
 dependencies = [
- "anchor-lang 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-lang 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "bolt-lang",
 ]
 
@@ -6021,7 +5994,7 @@ dependencies = [
 name = "world"
 version = "0.1.1"
 dependencies = [
- "anchor-lang 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anchor-lang 0.29.0 (git+https://github.com/coral-xyz/anchor.git?rev=d9a9f19)",
  "bolt-component",
  "bolt-helpers-world-apply",
  "bolt-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ bolt-system = { path = "programs/bolt-system", features = ["cpi"], version = "=0
 bolt-component = { path = "programs/bolt-component", features = ["cpi"], version = "=0.1.1"}
 
 ## External crates
-anchor-lang = "0.29.0"
-anchor-spl = "0.29.0"
+#anchor-lang = "0.29.0"
+anchor-lang = { git = "https://github.com/coral-xyz/anchor.git", rev = "d9a9f19" }
 solana-security-txt = "1.1.1"
 tuple-conv = "1.0.1"
 syn = { version = "1.0.60", features = ["full"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,9 +21,9 @@ lto = true
 dev = []
 
 [dependencies]
-anchor-cli = { git = "https://github.com/coral-xyz/anchor.git", rev = "e212105" }
-anchor-client = { git = "https://github.com/coral-xyz/anchor.git", rev = "e212105" }
-anchor-syn = { git = "https://github.com/coral-xyz/anchor.git", rev = "e212105" }
+anchor-cli = { git = "https://github.com/coral-xyz/anchor.git", rev = "d9a9f19" }
+anchor-client = { git = "https://github.com/coral-xyz/anchor.git", rev = "d9a9f19" }
+anchor-syn = { git = "https://github.com/coral-xyz/anchor.git", rev = "d9a9f19" }
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 heck = { workspace = true }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -6,6 +6,7 @@ use anchor_cli::config::{
     BootstrapMode, Config, ConfigOverride, GenesisEntry, ProgramArch, ProgramDeployment,
     TestValidator, Validator, WithPath,
 };
+use anchor_cli::rust_template::TestTemplate;
 use anchor_client::Cluster;
 use anchor_syn::idl::types::Idl;
 use anyhow::{anyhow, Result};
@@ -17,7 +18,6 @@ use std::io::Write;
 use std::io::{self, BufRead};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use anchor_cli::rust_template::TestTemplate;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const ANCHOR_VERSION: &str = anchor_cli::VERSION;
@@ -177,7 +177,8 @@ fn init(
 
     let mut cfg = Config::default();
     let test_script = test_template.get_test_script(javascript);
-    cfg.scripts.insert("test".to_owned(), test_script.to_owned());
+    cfg.scripts
+        .insert("test".to_owned(), test_script.to_owned());
     let jest = TestTemplate::Jest == test_template;
     if jest {
         cfg.scripts.insert(

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -17,6 +17,7 @@ use std::io::Write;
 use std::io::{self, BufRead};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use anchor_cli::rust_template::TestTemplate;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const ANCHOR_VERSION: &str = anchor_cli::VERSION;
@@ -70,8 +71,8 @@ pub fn entry(opts: Opts) -> Result<()> {
                 javascript,
                 solidity,
                 no_git,
-                jest,
                 template,
+                test_template,
                 force,
             } => init(
                 &opts.cfg_override,
@@ -79,8 +80,8 @@ pub fn entry(opts: Opts) -> Result<()> {
                 javascript,
                 solidity,
                 no_git,
-                jest,
                 template,
+                test_template,
                 force,
             ),
             anchor_cli::Command::Build {
@@ -136,8 +137,8 @@ fn init(
     javascript: bool,
     solidity: bool,
     no_git: bool,
-    jest: bool,
     template: anchor_cli::rust_template::ProgramTemplate,
+    test_template: anchor_cli::rust_template::TestTemplate,
     force: bool,
 ) -> Result<()> {
     if !force && Config::discover(cfg_override)?.is_some() {
@@ -175,6 +176,9 @@ fn init(
     fs::create_dir_all("app")?;
 
     let mut cfg = Config::default();
+    let test_script = test_template.get_test_script(javascript);
+    cfg.scripts.insert("test".to_owned(), test_script.to_owned());
+    let jest = TestTemplate::Jest == test_template;
     if jest {
         cfg.scripts.insert(
             "test".to_owned(),

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -1,7 +1,10 @@
 use crate::ANCHOR_VERSION;
 use crate::VERSION;
 use anchor_cli::Files;
-use anchor_syn::idl::types::{Idl, IdlArrayLen, IdlDefinedFields, IdlGenericArg, IdlType, IdlTypeDef, IdlTypeDefGeneric, IdlTypeDefTy};
+use anchor_syn::idl::types::{
+    Idl, IdlArrayLen, IdlDefinedFields, IdlGenericArg, IdlType, IdlTypeDef, IdlTypeDefGeneric,
+    IdlTypeDefTy,
+};
 use anyhow::Result;
 use heck::{ToSnakeCase, ToUpperCamelCase};
 use std::path::{Path, PathBuf};
@@ -486,7 +489,10 @@ pub fn registry_account() -> &'static str {
 
 pub fn component_type(idl: &Idl, component_id: &str) -> Result<String> {
     let component_account = &idl.accounts[0];
-    let type_def = &idl.types.iter().rfind(|ty| ty.name == component_account.name);
+    let type_def = &idl
+        .types
+        .iter()
+        .rfind(|ty| ty.name == component_account.name);
     let type_def = match type_def {
         Some(ty) => ty,
         None => return Err(anyhow::anyhow!("Component type not found in IDL")),
@@ -515,12 +521,14 @@ fn component_to_rust_code(component: &IdlTypeDef, component_id: &str) -> String 
     }
     // Handle generics
     let generics = {
-        let generic_names: Vec<String> = component.generics.iter().map(|gen| {
-            match gen {
+        let generic_names: Vec<String> = component
+            .generics
+            .iter()
+            .map(|gen| match gen {
                 IdlTypeDefGeneric::Type { name } => name.clone(),
                 IdlTypeDefGeneric::Const { name, .. } => name.clone(),
-            }
-        }).collect();
+            })
+            .collect();
         format!("<{}>", generic_names.join(", "))
     };
     let composite_name = format!("Component{}", component_id);
@@ -561,14 +569,14 @@ fn component_fields_to_rust_code(fields: &Option<IdlDefinedFields>) -> String {
                     let field_type = idl_type_to_rust_type(&field.ty);
                     code += &format!("    pub {}: {},\n", field.name, field_type);
                 }
-            },
+            }
             IdlDefinedFields::Tuple(tuple_types) => {
                 for (index, ty) in tuple_types.iter().enumerate() {
                     let field_type = idl_type_to_rust_type(ty);
                     // Tuple fields are unnamed, so using index as part of the field name
                     code += &format!("    pub field_{}: {},\n", index, field_type);
                 }
-            },
+            }
         }
     }
     code
@@ -595,10 +603,14 @@ fn idl_type_to_rust_type(idl_type: &IdlType) -> String {
         IdlType::Bytes => "Vec<u8>".to_string(),
         IdlType::String => "String".to_string(),
         IdlType::Pubkey => "PublicKey".to_string(),
-        IdlType::Defined { name, generics} => defined_to_rust_type(name, generics),
+        IdlType::Defined { name, generics } => defined_to_rust_type(name, generics),
         IdlType::Option(ty) => format!("Option<{}>", idl_type_to_rust_type(ty)),
         IdlType::Vec(ty) => format!("Vec<{}>", idl_type_to_rust_type(ty)),
-        IdlType::Array(ty, size) => format!("[{}; {}]", idl_type_to_rust_type(ty), idl_array_len_to_rust_len(size)),
+        IdlType::Array(ty, size) => format!(
+            "[{}; {}]",
+            idl_type_to_rust_type(ty),
+            idl_array_len_to_rust_len(size)
+        ),
         IdlType::Generic(name) => name.clone(),
     }
 }
@@ -615,7 +627,15 @@ fn defined_to_rust_type(name: &String, generics: &Vec<IdlGenericArg>) -> String 
     if generics.is_empty() {
         name.clone()
     } else {
-        format!("{}<{}>", name, generics.iter().map(idl_defined_type_arg_to_rust_type).collect::<Vec<_>>().join(", "))
+        format!(
+            "{}<{}>",
+            name,
+            generics
+                .iter()
+                .map(idl_defined_type_arg_to_rust_type)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
     }
 }
 
@@ -648,12 +668,13 @@ fn component_type_to_rust_code(component_type: &IdlTypeDef) -> String {
     // Handle generics
     let gen = &component_type.generics;
     let generics = {
-        let generic_names: Vec<String> = gen.iter().map(|gen| {
-            match gen {
+        let generic_names: Vec<String> = gen
+            .iter()
+            .map(|gen| match gen {
                 IdlTypeDefGeneric::Type { name } => name.clone(),
                 IdlTypeDefGeneric::Const { name, .. } => name.clone(),
-            }
-        }).collect();
+            })
+            .collect();
         format!("<{}>", generic_names.join(", "))
     };
     if let IdlTypeDefTy::Struct { fields } = &component_type.ty {

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -623,7 +623,7 @@ fn idl_array_len_to_rust_len(idl_array_len: &IdlArrayLen) -> String {
 }
 
 /// Map defined type to rust type
-fn defined_to_rust_type(name: &String, generics: &Vec<IdlGenericArg>) -> String {
+fn defined_to_rust_type(name: &String, generics: &[IdlGenericArg]) -> String {
     if generics.is_empty() {
         name.clone()
     } else {

--- a/examples/system-apply-velocity/Cargo.toml
+++ b/examples/system-apply-velocity/Cargo.toml
@@ -22,7 +22,6 @@ idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]
 anchor-lang = { workspace = true }
-anchor-spl = { workspace = true, features = ["metadata"]}
 bolt-lang = { path = "../../crates/bolt-lang" }
 velocity = { path = "../component-velocity", features = ["cpi"]}
 position = { path = "../component-position", features = ["cpi"]}

--- a/examples/system-apply-velocity/src/lib.rs
+++ b/examples/system-apply-velocity/src/lib.rs
@@ -1,4 +1,3 @@
-use anchor_spl::metadata::Metadata;
 use bolt_lang::*;
 use position::Position;
 use velocity::Velocity;
@@ -35,7 +34,5 @@ pub mod system_apply_velocity {
         pub sysvar_clock: AccountInfo,
         #[account(address = pubkey!("6LHhFVwif6N9Po3jHtSmMVtPjF6zRfL3xMosSzcrQAS8"))]
         pub some_extra_account: AccountInfo,
-        #[account(address = Metadata::id())]
-        pub program_metadata: Program<Metadata>,
     }
 }

--- a/programs/bolt-component/src/lib.rs
+++ b/programs/bolt-component/src/lib.rs
@@ -65,7 +65,8 @@ pub mod bolt_component {
         /// CHECK: The authority of the component
         pub authority: AccountInfo<'info>,
         #[account(address = anchor_lang::solana_program::sysvar::instructions::id())]
-        pub instruction_sysvar_account: UncheckedAccount<'info>,
+        /// CHECK: The instruction sysvar account
+        pub instruction_sysvar_account: AccountInfo<'info>,
     }
 }
 
@@ -82,7 +83,8 @@ pub struct Initialize<'info> {
     /// CHECK: The authority of the component
     pub authority: AccountInfo<'info>,
     #[account(address = anchor_lang::solana_program::sysvar::instructions::id())]
-    pub instruction_sysvar_account: UncheckedAccount<'info>,
+    /// CHECK: The instruction sysvar account
+    pub instruction_sysvar_account: AccountInfo<'info>,
     pub system_program: Program<'info, System>,
 }
 

--- a/programs/world/src/lib.rs
+++ b/programs/world/src/lib.rs
@@ -141,7 +141,7 @@ pub struct AddEntity<'info> {
         None => &[],
     }], bump)]
     pub entity: Account<'info, Entity>,
-    #[account(mut, address = world.pda().0)]
+    #[account(mut)]
     pub world: Account<'info, World>,
     pub system_program: Program<'info, System>,
 }


### PR DESCRIPTION
# :sparkles: Upgrade to latest anchor version, supporting the new IDL standard

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Hold | Feature | No | - |

## Problem

Support the new IDL standard defined in https://github.com/coral-xyz/anchor/pull/2824

- This includes some important features, such as the address field in the accounts 

## Dependencies

- Need to complete #28 before merging, as the new standard has core changes which need to be included in the components and systems. Removing the anchor-lang dependency will also ensure that the same anchor version is used. 
