### PR TITLE
:sparkles: Propagate signing authority to the systems

### DIFF
--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -385,6 +385,7 @@ describe("{}", () => {{
           componentProgram: positionComponent.programId,
           boltSystem: systemMovement.programId,
           boltComponent: positionComponentPda,
+          authority: provider.wallet.publicKey,
       }}, {{args: new Uint8Array()}});
 
       const tx = new anchor.web3.Transaction().add(applySystemIx);

--- a/crates/bolt-helpers/attribute/system-template/src/lib.rs
+++ b/crates/bolt-helpers/attribute/system-template/src/lib.rs
@@ -54,6 +54,8 @@ pub fn system_template(attr: TokenStream, item: TokenStream) -> TokenStream {
             #[derive(Accounts)]
             pub struct #data_struct<'info> {
                 #(#fields)*
+                #[account()]
+                pub authority: Signer<'info>,
             }
         };
         quote! {

--- a/crates/bolt-helpers/attribute/world-apply/src/lib.rs
+++ b/crates/bolt-helpers/attribute/world-apply/src/lib.rs
@@ -92,7 +92,7 @@ pub fn apply_system(attr: TokenStream, item: TokenStream) -> TokenStream {
                 pub bolt_system: UncheckedAccount<'info>,
                 #(#fields)*
                  /// CHECK: authority check
-                pub authority: UncheckedAccount<'info>,
+                pub authority: Signer<'info>,
                 #[account(address = anchor_lang::solana_program::sysvar::instructions::id())]
                 /// CHECK: instruction sysvar check
                 pub instruction_sysvar_account: UncheckedAccount<'info>,
@@ -119,6 +119,7 @@ pub fn apply_system(attr: TokenStream, item: TokenStream) -> TokenStream {
                     let cpi_program = self.bolt_system.to_account_info();
                     let cpi_accounts = bolt_system::cpi::accounts::#set_data_struct {
                         #(#fields)*
+                        authority: self.authority.to_account_info(),
                     };
                     CpiContext::new(cpi_program, cpi_accounts)
                 }

--- a/crates/bolt-lang/attribute/bolt-program/src/lib.rs
+++ b/crates/bolt-lang/attribute/bolt-program/src/lib.rs
@@ -156,7 +156,7 @@ fn generate_update(component_type: &Type) -> (TokenStream2, TokenStream2) {
                     return Err(BoltError::InvalidCaller.into());
                 }
                 // Check if the authority is authorized to modify the data
-                if ctx.accounts.bolt_component.bolt_metadata.authority != World::id() && ctx.accounts.bolt_component.bolt_metadata.authority != *ctx.accounts.authority.key {
+                if ctx.accounts.bolt_component.bolt_metadata.authority != World::id() && (ctx.accounts.bolt_component.bolt_metadata.authority != *ctx.accounts.authority.key || !ctx.accounts.authority.is_signer) {
                     return Err(BoltError::InvalidAuthority.into());
                 }
 

--- a/crates/bolt-lang/attribute/system-input/src/lib.rs
+++ b/crates/bolt-lang/attribute/system-input/src/lib.rs
@@ -76,6 +76,7 @@ pub fn system_input(_attr: TokenStream, item: TokenStream) -> TokenStream {
         #[derive(Accounts)]
         pub struct #name<'info> {
             #(#transformed_fields)*
+            pub authority: Signer<'info>,
         }
     };
 

--- a/examples/system-apply-velocity/src/lib.rs
+++ b/examples/system-apply-velocity/src/lib.rs
@@ -20,6 +20,7 @@ pub mod system_apply_velocity {
         msg!("last applied: {}", ctx.accounts.velocity.last_applied);
         msg!("Position: {}", ctx.accounts.position.x);
         msg!("Remaining accounts: {}", ctx.remaining_accounts.len());
+        msg!("Authority: {}", ctx.accounts.authority.key);
         Ok(ctx.accounts)
     }
 

--- a/programs/bolt-component/src/lib.rs
+++ b/programs/bolt-component/src/lib.rs
@@ -30,6 +30,7 @@ pub mod bolt_component {
         pub bolt_component: Account<'info, Component>,
         /// CHECK: The system can modify the data of the component
         pub bolt_system: UncheckedAccount<'info>,
+        pub authority: Signer<'info>,
     }
 
     impl<'info> Apply<'info> {
@@ -39,6 +40,7 @@ pub mod bolt_component {
             let cpi_program = self.bolt_system.to_account_info();
             let cpi_accounts = bolt_system::cpi::accounts::SetData {
                 component: self.bolt_component.to_account_info().clone(),
+                authority: self.authority.to_account_info(),
             };
             CpiContext::new(cpi_program, cpi_accounts)
         }

--- a/programs/bolt-system/src/lib.rs
+++ b/programs/bolt-system/src/lib.rs
@@ -18,4 +18,6 @@ pub struct SetData<'info> {
     #[account()]
     /// CHECK: unchecked account
     pub component: UncheckedAccount<'info>,
+    #[account()]
+    pub authority: Signer<'info>,
 }

--- a/programs/world/src/lib.rs
+++ b/programs/world/src/lib.rs
@@ -87,7 +87,7 @@ pub mod world {
         /// CHECK: component account
         pub bolt_component: UncheckedAccount<'info>,
         /// CHECK: authority check
-        pub authority: UncheckedAccount<'info>,
+        pub authority: Signer<'info>,
         #[account(address = anchor_lang::solana_program::sysvar::instructions::id())]
         /// CHECK: instruction sysvar check
         pub instruction_sysvar_account: UncheckedAccount<'info>,
@@ -100,6 +100,7 @@ pub mod world {
             let cpi_program = self.bolt_system.to_account_info();
             let cpi_accounts = bolt_system::cpi::accounts::SetData {
                 component: self.bolt_component.to_account_info(),
+                authority: self.authority.to_account_info(),
             };
             CpiContext::new(cpi_program, cpi_accounts)
         }
@@ -240,7 +241,7 @@ impl Entity {
 pub fn build_update_context<'info>(
     component_program: UncheckedAccount<'info>,
     component: UncheckedAccount<'info>,
-    authority: UncheckedAccount<'info>,
+    authority: Signer<'info>,
     instruction_sysvar_account: UncheckedAccount<'info>,
 ) -> CpiContext<'info, 'info, 'info, 'info, bolt_component::cpi::accounts::Update<'info>> {
     let cpi_program = component_program.to_account_info();

--- a/tests/bolt.ts
+++ b/tests/bolt.ts
@@ -335,9 +335,9 @@ describe("bolt", () => {
         boltSystem: systemSimpleMovement,
         boltComponent: componentPositionEntity1,
         instructionSysvarAccount: SYSVAR_INSTRUCTIONS_PUBKEY,
-        authority: worldProgram.programId,
+        authority: provider.wallet.publicKey,
       })
-      .rpc({ skipPreflight: true });
+      .rpc();
 
     expect(
       (
@@ -381,7 +381,7 @@ describe("bolt", () => {
         boltSystem: systemSimpleMovement,
         boltComponent: componentPositionEntity1,
         instructionSysvarAccount: SYSVAR_INSTRUCTIONS_PUBKEY,
-        authority: worldProgram.programId,
+        authority: provider.wallet.publicKey,
       })
       .rpc();
 
@@ -430,7 +430,7 @@ describe("bolt", () => {
         boltSystem: systemFly,
         boltComponent: componentPositionEntity1,
         instructionSysvarAccount: SYSVAR_INSTRUCTIONS_PUBKEY,
-        authority: worldProgram.programId,
+        authority: provider.wallet.publicKey,
       })
       .rpc();
 
@@ -474,7 +474,7 @@ describe("bolt", () => {
         boltComponent1: componentVelocityEntity1,
         boltComponent2: componentPositionEntity1,
         instructionSysvarAccount: SYSVAR_INSTRUCTIONS_PUBKEY,
-        authority: worldProgram.programId,
+        authority: provider.wallet.publicKey,
       })
       .rpc();
 
@@ -535,7 +535,7 @@ describe("bolt", () => {
         boltComponent1: componentVelocityEntity1,
         boltComponent2: componentPositionEntity1,
         instructionSysvarAccount: SYSVAR_INSTRUCTIONS_PUBKEY,
-        authority: worldProgram.programId,
+        authority: provider.wallet.publicKey,
       })
       .remainingAccounts([
         {
@@ -571,7 +571,7 @@ describe("bolt", () => {
           boltSystem: systemFly,
           boltComponent: componentPositionEntity5,
           instructionSysvarAccount: SYSVAR_INSTRUCTIONS_PUBKEY,
-          authority: worldProgram.programId,
+          authority: provider.wallet.publicKey,
         })
         .rpc();
     } catch (e) {


### PR DESCRIPTION
# :sparkles: Propagate signing authority to the systems

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | Yes | #6  |

## Problem

See #6 

## Solution

All systems can access the signing authority with `ctx.accounts.authority`

## Issues

Closes #6 