### PR TITLE
:adhesive_bandage: Explicit Default in components to allow custom defaults

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,7 +46,7 @@ jobs:
           yarn --frozen-lockfile --network-concurrency 2
 
       - name: install rust
-        uses: dtolnay/rust-toolchain@${{ env.rust_version }}
+        uses: dtolnay/rust-toolchain@1.75.0
         with:
           toolchain: stable
 
@@ -98,7 +98,7 @@ jobs:
 
     steps:
       - name: install rust
-        uses: dtolnay/rust-toolchain@${{ env.rust_version }}
+        uses: dtolnay/rust-toolchain@1.75.0
         with:
           toolchain: stable
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,7 +46,7 @@ jobs:
           yarn --frozen-lockfile --network-concurrency 2
 
       - name: install rust
-        uses: dtolnay/rust-toolchain@1.75.0
+        uses: dtolnay/rust-toolchain@${{ env.rust_version }}
         with:
           toolchain: stable
 
@@ -98,7 +98,7 @@ jobs:
 
     steps:
       - name: install rust
-        uses: dtolnay/rust-toolchain@1.75.0
+        uses: dtolnay/rust-toolchain@${{ env.rust_version }}
         with:
           toolchain: stable
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  solana_version: v1.18.1
+  solana_version: v1.18.8
   anchor_version: 0.29.0
 
 jobs:
@@ -45,7 +45,7 @@ jobs:
           yarn --frozen-lockfile --network-concurrency 2
 
       - name: install rust
-        uses: dtolnay/rust-toolchain@1.75.0
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
 
@@ -97,7 +97,7 @@ jobs:
 
     steps:
       - name: install rust
-        uses: dtolnay/rust-toolchain@1.75.0
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   solana_version: v1.18.1
-  rust_version: 1.75.0
   anchor_version: 0.29.0
 
 jobs:
@@ -46,7 +45,7 @@ jobs:
           yarn --frozen-lockfile --network-concurrency 2
 
       - name: install rust
-        uses: dtolnay/rust-toolchain@${{ env.rust_version }}
+        uses: dtolnay/rust-toolchain@1.75.0
         with:
           toolchain: stable
 
@@ -98,7 +97,7 @@ jobs:
 
     steps:
       - name: install rust
-        uses: dtolnay/rust-toolchain@${{ env.rust_version }}
+        uses: dtolnay/rust-toolchain@1.75.0
         with:
           toolchain: stable
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   solana_version: v1.18.1
+  rust_version: 1.75.0
   anchor_version: 0.29.0
 
 jobs:
@@ -45,7 +46,7 @@ jobs:
           yarn --frozen-lockfile --network-concurrency 2
 
       - name: install rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@${{ env.rust_version }}
         with:
           toolchain: stable
 
@@ -97,7 +98,7 @@ jobs:
 
     steps:
       - name: install rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@${{ env.rust_version }}
         with:
           toolchain: stable
 

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -50,7 +50,7 @@ fn create_component_template_simple(name: &str, program_path: &Path) -> Files {
 declare_id!("{}");
 
 #[component]
-#[derive(Copy, Default)]
+#[derive(Default)]
 pub struct {} {{
     pub x: i64,
     pub y: i64,

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -50,6 +50,7 @@ fn create_component_template_simple(name: &str, program_path: &Path) -> Files {
 declare_id!("{}");
 
 #[component]
+#[derive(Copy, Default)]
 pub struct {} {{
     pub x: i64,
     pub y: i64,

--- a/crates/bolt-lang/attribute/component/src/lib.rs
+++ b/crates/bolt-lang/attribute/component/src/lib.rs
@@ -55,7 +55,7 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
     let component_id_value = component_id_value.unwrap_or_else(|| "".to_string());
 
     let additional_macro: Attribute = parse_quote! { #[account] };
-    let additional_derives: Attribute = parse_quote! { #[derive(InitSpace, Default)] };
+    let additional_derives: Attribute = parse_quote! { #[derive(InitSpace)] };
     input.attrs.push(additional_derives);
 
     add_bolt_metadata(&mut input);

--- a/examples/component-position/src/lib.rs
+++ b/examples/component-position/src/lib.rs
@@ -3,7 +3,7 @@ use bolt_lang::*;
 declare_id!("Fn1JzzEdyb55fsyduWS94mYHizGhJZuhvjX6DVvrmGbQ");
 
 #[component]
-#[derive(Copy)]
+#[derive(Copy, Default)]
 pub struct Position {
     pub x: i64,
     pub y: i64,

--- a/examples/component-velocity/src/lib.rs
+++ b/examples/component-velocity/src/lib.rs
@@ -3,6 +3,7 @@ use bolt_lang::*;
 declare_id!("CbHEFbSQdRN4Wnoby9r16umnJ1zWbULBHg4yqzGQonU1");
 
 #[component(component_id = "component-velocity")]
+#[derive(Default)]
 pub struct Velocity {
     pub x: i64,
     pub y: i64,


### PR DESCRIPTION
# :adhesive_bandage: Explicit Default in components to allow custom defaults

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature/Refactor | Yes| #4  |

## Problem

Difficult to override defaults, `Derive(Default)` implicitly added by the macro 

## Solution

Components now explicitly derive Default, so that it could be implemented alternatively:

e.g.
```rust
#[component]
#[derive(Copy)]
pub struct Position {
    pub x: i64,
    pub y: i64,
    pub z: i64,
}

impl Default for Position {
    fn default() -> Self {
        Self {
            x: 100,
            y: 0,
            z: 0,
            bolt_metadata: BoltMetadata::default(),
        }
    }
}
```

## Issues
Closes #4 