### PR TITLE
:sparkles: Simplify component_deserialize macro

### DIFF
--- a/crates/bolt-lang/attribute/component-deserialize/src/lib.rs
+++ b/crates/bolt-lang/attribute/component-deserialize/src/lib.rs
@@ -19,7 +19,7 @@ pub fn component_deserialize(_attr: TokenStream, item: TokenStream) -> TokenStre
 
     // Add the AnchorDeserialize and AnchorSerialize derives to the struct
     let additional_derives: Attribute =
-        syn::parse_quote! { #[derive(bolt_lang::AnchorDeserialize, bolt_lang::AnchorSerialize)] };
+        syn::parse_quote! { #[derive(bolt_lang::InitSpace, bolt_lang::AnchorDeserialize, bolt_lang::AnchorSerialize, Clone, Copy)] };
     input.attrs.push(additional_derives);
 
     let name = &input.ident.clone();

--- a/crates/bolt-lang/attribute/component-deserialize/src/lib.rs
+++ b/crates/bolt-lang/attribute/component-deserialize/src/lib.rs
@@ -18,8 +18,7 @@ pub fn component_deserialize(_attr: TokenStream, item: TokenStream) -> TokenStre
     let mut input = parse_macro_input!(item as DeriveInput);
 
     // Add the AnchorDeserialize and AnchorSerialize derives to the struct
-    let additional_derives: Attribute =
-        syn::parse_quote! { #[derive(bolt_lang::InitSpace, bolt_lang::AnchorDeserialize, bolt_lang::AnchorSerialize, Clone, Copy)] };
+    let additional_derives: Attribute = syn::parse_quote! { #[derive(bolt_lang::InitSpace, bolt_lang::AnchorDeserialize, bolt_lang::AnchorSerialize, Clone, Copy)] };
     input.attrs.push(additional_derives);
 
     let name = &input.ident.clone();

--- a/crates/bolt-lang/attribute/component/src/lib.rs
+++ b/crates/bolt-lang/attribute/component/src/lib.rs
@@ -1,7 +1,9 @@
-use bolt_utils::add_bolt_metadata;
 use proc_macro::TokenStream;
+
 use quote::quote;
 use syn::{parse_macro_input, parse_quote, Attribute, DeriveInput, Lit, Meta, NestedMeta};
+
+use bolt_utils::add_bolt_metadata;
 
 /// This Component attribute is used to automatically generate the seed and size functions
 ///
@@ -58,6 +60,10 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
     let additional_derives: Attribute = parse_quote! { #[derive(InitSpace)] };
     input.attrs.push(additional_derives);
 
+    let new_fn = define_new_fn(&input);
+    // print new_fn
+    println!("{:?}", new_fn);
+
     add_bolt_metadata(&mut input);
 
     let name = &input.ident;
@@ -76,6 +82,8 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
         #additional_macro
         #input
 
+        #new_fn
+
         #[automatically_derived]
         impl ComponentTraits for #name {
             fn seed() -> &'static [u8] {
@@ -86,6 +94,42 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
                 8 + <#name>::INIT_SPACE
             }
         }
+
     };
     expanded.into()
+}
+
+/// Create a fn `new` to initialize the struct without bolt_metadata field
+fn define_new_fn(input: &DeriveInput) -> proc_macro2::TokenStream {
+    let struct_name = &input.ident;
+
+    if let syn::Data::Struct(ref data) = input.data {
+        if let syn::Fields::Named(ref fields) = data.fields {
+            // Generate function parameters and struct initialization code for each field
+            let params = fields.named.iter().map(|f| {
+                let name = &f.ident;
+                let ty = &f.ty;
+                quote! { #name: #ty }
+            });
+
+            let init_fields = fields.named.iter().map(|f| {
+                let name = &f.ident;
+                quote! { #name: #name }
+            });
+
+            // Generate the new function
+            let new_fn = quote! {
+                impl #struct_name {
+                    pub fn new(#(#params),*) -> Self {
+                        Self {
+                            #(#init_fields,)*
+                            bolt_metadata: BoltMetadata::default(),
+                        }
+                    }
+                }
+            };
+            return new_fn;
+        }
+    }
+    quote! {}
 }

--- a/crates/types/src/component_Fn1JzzEdyb55fsyduWS94mYHizGhJZuhvjX6DVvrmGbQ.rs
+++ b/crates/types/src/component_Fn1JzzEdyb55fsyduWS94mYHizGhJZuhvjX6DVvrmGbQ.rs
@@ -1,7 +1,6 @@
 use bolt_lang::*;
 
 #[component_deserialize]
-#[derive(Clone, Copy)]
 pub struct ComponentFn1JzzEdyb55fsyduWS94mYHizGhJZuhvjX6DVvrmGbQ {
     pub x: i64,
     pub y: i64,
@@ -11,7 +10,6 @@ pub struct ComponentFn1JzzEdyb55fsyduWS94mYHizGhJZuhvjX6DVvrmGbQ {
 pub use ComponentFn1JzzEdyb55fsyduWS94mYHizGhJZuhvjX6DVvrmGbQ as Position;
 
 #[component_deserialize]
-#[derive(Clone, Copy)]
 pub struct Entity {
     pub id: u64,
 }


### PR DESCRIPTION
# Simplify component_deserialize macro

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature/Refactor | No | - |

## Problem

component_deserialize tipically used with `copy` and `clone` derives 

## Solution

Automatically add `copy` and `clone` derive when using component_deserialize

## Other changes

Add a `new` constructor which allows to build component without `bolt_metadata` field 