### PR TITLE
fix: make sure CI is recompiling the /lib folder when we make changes

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Cache node dependencies
         uses: actions/cache@v3
         with:
-          path: '**/node_modules'
+          path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: install node_modules
@@ -84,7 +84,7 @@ jobs:
       - name: Cache node dependencies
         uses: actions/cache@v4
         with:
-          path: '**/node_modules'
+          path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Run lint
@@ -113,8 +113,9 @@ jobs:
       - name: Cache node dependencies
         uses: actions/cache@v3
         with:
-          path: '**/node_modules'
+          path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
       - name: install node_modules
         run: |
           export PATH="/home/runner/.local/share/solana/install/active_release/bin:$PATH"
@@ -158,6 +159,12 @@ jobs:
           export PATH="/home/runner/.local/share/solana/install/active_release/bin:$PATH"
           cargo install --path cli --force --locked
           bolt test
+
+      - name: Generate lib
+        run: |
+          cd clients/bolt-sdk
+          yarn build
+          cd ../..
 
       - name: Install the Bolt CLI and create & build a new project
         shell: bash

--- a/clients/bolt-sdk/README.md
+++ b/clients/bolt-sdk/README.md
@@ -12,7 +12,7 @@ npm install @magicblock-labs/bolt-sdk
 
 ## Contributing
 
-The community is encouraged to contribute to the Soar SDK.
+The community is encouraged to contribute to the BOLT SDK.
 
 Fixes and features are always welcome! Please feel free to submit a PR for review.
 


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Bug/Tooling | No | -- |

## Problem

When changing the Typescript files, yarn build was not running in the CI, leading to the CI's test succeeding even if we just introduced a bug.

## Solution

Make the CI run `yarn build` before testing
