### PR TITLE
fix: secret ENV variables should be read by forked PR's also

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,7 +3,9 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
+    branches:
+      - main
 
 env:
   solana_version: v1.18.15


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| fix | Yes| [Link](<Issue link here>) |

## Problem

Contributor tests where failing when creating the **PR** from **Forked repository**.

Reason: https://github.com/magicblock-labs/bolt/pull/74#issuecomment-2296055732


## Solution

Added the `pull_request_target` for fork repository also.

