### PR TITLE
feat: Add authority approval/removal for world instances

### DIFF
--- a/.github/workflows/publish-bolt-crates.yml
+++ b/.github/workflows/publish-bolt-crates.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Cache rust
         uses: Swatinem/rust-cache@v2
       - name: Run fmt
-        run: cargo fmt -- --check
+        run: cargo fmt -- --check --verbose
       - name: Run clippy
         run: cargo clippy -- --deny=warnings
 

--- a/.github/workflows/publish-bolt-sdk.yml
+++ b/.github/workflows/publish-bolt-sdk.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Cache rust
         uses: Swatinem/rust-cache@v2
       - name: Run fmt
-        run: cargo fmt -- --check
+        run: cargo fmt -- --check --verbose
       - name: Run clippy
         run: cargo clippy -- --deny=warnings
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 21
 
       - name: install essentials
         run: |
@@ -71,8 +71,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Check Rust version
         run: rustc --version
-#      - name: Run fmt
-#        run: cargo fmt -- --check --verbose
+      - name: Run fmt
+        run: cargo fmt -- --check --verbose
       - name: Run clippy
         run: cargo clippy -- --deny=warnings
 

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,7 +1,7 @@
 [toolchain]
 
 [features]
-seeds = true
+resolution = true
 skip-lint = false
 
 [programs.devnet]
@@ -20,30 +20,29 @@ velocity = "CbHEFbSQdRN4Wnoby9r16umnJ1zWbULBHg4yqzGQonU1"
 url = "https://api.apr.dev"
 
 [provider]
-cluster = "localnet"
+cluster = "Localnet"
 wallet = "./tests/fixtures/provider.json"
+
+[workspace]
+members = ["programs/bolt-component", "programs/bolt-system", "programs/world", "examples/component-position", "examples/component-velocity", "examples/system-apply-velocity", "examples/system-fly", "examples/system-simple-movement"]
+
+[scripts]
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/bolt.ts"
 
 [test]
 startup_wait = 5000
 shutdown_wait = 2000
 upgradeable = false
 
-[workspace]
-members = [
-    "programs/bolt-component",
-    "programs/bolt-system",
-    "programs/world",
-    "examples/component-position",
-    "examples/component-velocity",
-    "examples/system-apply-velocity",
-    "examples/system-fly",
-    "examples/system-simple-movement",
-]
-
 [[test.genesis]]
 address = "DELeGGvXpWV2fqJUhqcF5ZSYMS4JTLjteaAMARRSaeSh"
 program = "tests/fixtures/delegation.so"
 upgradeable = false
+
+[test.validator]
+bind_address = "0.0.0.0"
+ledger = ".anchor/test-ledger"
+rpc_port = 8899
 
 [[test.validator.account]]
 address = "EEmsg7GbxEAw5f9hGfZRmJRJ27HK8KeGDp7ViW9X2mYa"
@@ -52,6 +51,3 @@ filename = "tests/fixtures/commit_record.json"
 [[test.validator.account]]
 address = "7nQvHcfEqtFmY2q6hiQbidu8BCNdqegnEFfH7HkByFn5"
 filename = "tests/fixtures/committed_state.json"
-
-[scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/bolt.ts"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,6 +1018,7 @@ dependencies = [
  "heck 0.5.0",
  "serde_json",
  "syn 1.0.109",
+ "world 0.1.9",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,3 +30,4 @@ serde_json = { workspace = true }
 heck = { workspace = true }
 clap = { workspace = true }
 syn = { workspace = true, features = ["full", "extra-traits"] }
+world = { workspace = true }

--- a/cli/src/instructions.rs
+++ b/cli/src/instructions.rs
@@ -1,0 +1,147 @@
+use anchor_cli::config::{Config, ConfigOverride};
+use anchor_client::solana_client::rpc_config::RpcSendTransactionConfig;
+use anchor_client::solana_sdk::commitment_config::CommitmentConfig;
+use anchor_client::solana_sdk::pubkey::Pubkey;
+use anchor_client::solana_sdk::signature::{read_keypair_file, Keypair};
+use anchor_client::solana_sdk::signer::Signer;
+use anchor_client::solana_sdk::system_program;
+use anyhow::{anyhow, Result};
+use std::rc::Rc;
+use anchor_client::Client;
+use world::{accounts, instruction, World, ID};
+
+fn setup_client(cfg_override: &ConfigOverride) -> Result<(Client<Rc<Keypair>>, Keypair)> {
+    let cfg = Config::discover(cfg_override)?.expect("Not in workspace.");
+    let wallet_path = cfg.provider.wallet.clone();
+
+    let payer = read_keypair_file(wallet_path.to_string())
+        .map_err(|e| anyhow!("Failed to read keypair file: {}", e))?;
+
+    let payer_for_client =
+        Keypair::from_bytes(&payer.to_bytes()).expect("Failed to create Keypair from bytes");
+
+    let client = Client::new_with_options(
+        cfg.provider.cluster.clone(),
+        Rc::new(payer_for_client),
+        CommitmentConfig::confirmed(),
+    );
+    Ok((client, payer))
+}
+
+fn parse_pubkey(input: &str, error_message: &str) -> Result<Pubkey> {
+    input.parse::<Pubkey>().map_err(|_| anyhow!(error_message.to_string()))}
+
+pub fn authorize(cfg_override: &ConfigOverride, world: String, new_authority: String) -> Result<()> {
+    let world_pubkey = parse_pubkey(&world, "Invalid world public key")?;
+    let new_authority_pubkey = parse_pubkey(&new_authority, "Invalid new authority public key")?;
+
+    let (client, payer) = setup_client(cfg_override)?;
+    let program = client.program(ID)?;
+
+    let world_account = program.account::<World>(world_pubkey)?;
+    let world_id = world_account.id;
+    let signature = program
+        .request()
+        .accounts(accounts::AddAuthority {
+            authority: payer.pubkey(),
+            new_authority: new_authority_pubkey,
+            system_program: system_program::ID,
+            world: world_pubkey,
+        })
+        .args(instruction::AddAuthority { world_id })
+        .signer(&payer)
+        .send()?;
+
+    println!(
+        "Authority {} added to world {} with signature {}",
+        new_authority, world, signature
+    );
+
+    Ok(())
+}
+
+pub fn deauthorize(cfg_override: &ConfigOverride, world: String, authority_to_delete: String) -> Result<()> {
+    let world_pubkey = parse_pubkey(&world, "Invalid world public key")?;
+    let authority_to_delete_pubkey = parse_pubkey(&authority_to_delete, "Invalid authority public key")?;
+
+    let (client, payer) = setup_client(cfg_override)?;
+    let program = client.program(ID)?;
+
+    let world_account = program.account::<World>(world_pubkey)?;
+    let world_id = world_account.id;
+    let signature = program
+        .request()
+        .accounts(accounts::RemoveAuthority {
+            authority: payer.pubkey(),
+            authority_to_delete: authority_to_delete_pubkey,
+            system_program: system_program::ID,
+            world: world_pubkey,
+        })
+        .args(instruction::RemoveAuthority { world_id })
+        .signer(&payer)
+        .send_with_spinner_and_config(RpcSendTransactionConfig {
+            skip_preflight: true,
+            ..RpcSendTransactionConfig::default()
+        })?;
+
+    println!(
+        "Authority {} removed from world {} with signature {}",
+        authority_to_delete, world, signature
+    );
+
+    Ok(())
+}
+
+pub fn approve_system(cfg_override: &ConfigOverride, world: String, system_to_approve: String) -> Result<()> {
+    let world_pubkey = parse_pubkey(&world, "Invalid world public key")?;
+    let system_to_approve_pubkey = parse_pubkey(&system_to_approve, "Invalid system public key")?;
+
+    let (client, payer) = setup_client(cfg_override)?;
+    let program = client.program(ID)?;
+
+    let signature = program
+        .request()
+        .accounts(accounts::ApproveSystem {
+            authority: payer.pubkey(),
+            system: system_to_approve_pubkey,
+            world: world_pubkey,
+            system_program: system_program::ID,
+        })
+        .args(instruction::ApproveSystem {})
+        .signer(&payer)
+        .send()?;
+
+    println!(
+        "System {} approved for world {} with signature {}",
+        system_to_approve, world, signature
+    );
+
+    Ok(())
+}
+
+pub fn remove_system(cfg_override: &ConfigOverride, world: String, system_to_remove: String) -> Result<()> {
+    let world_pubkey = parse_pubkey(&world, "Invalid world public key")?;
+    let system_to_remove_pubkey = parse_pubkey(&system_to_remove, "Invalid system public key")?;
+
+    let (client, payer) = setup_client(cfg_override)?;
+    let program = client.program(ID)?;
+
+    let signature = program
+        .request()
+        .accounts(accounts::RemoveSystem {
+            authority: payer.pubkey(),
+            system: system_to_remove_pubkey,
+            world: world_pubkey,
+            system_program: system_program::ID,
+        })
+        .args(instruction::RemoveSystem {})
+        .signer(&payer)
+        .send()?;
+
+    println!(
+        "System {} removed from world {} with signature {}",
+        system_to_remove, world, signature
+    );
+
+    Ok(())
+}

--- a/cli/src/instructions.rs
+++ b/cli/src/instructions.rs
@@ -5,9 +5,9 @@ use anchor_client::solana_sdk::pubkey::Pubkey;
 use anchor_client::solana_sdk::signature::{read_keypair_file, Keypair};
 use anchor_client::solana_sdk::signer::Signer;
 use anchor_client::solana_sdk::system_program;
+use anchor_client::Client;
 use anyhow::{anyhow, Result};
 use std::rc::Rc;
-use anchor_client::Client;
 use world::{accounts, instruction, World, ID};
 
 fn setup_client(cfg_override: &ConfigOverride) -> Result<(Client<Rc<Keypair>>, Keypair)> {
@@ -29,9 +29,16 @@ fn setup_client(cfg_override: &ConfigOverride) -> Result<(Client<Rc<Keypair>>, K
 }
 
 fn parse_pubkey(input: &str, error_message: &str) -> Result<Pubkey> {
-    input.parse::<Pubkey>().map_err(|_| anyhow!(error_message.to_string()))}
+    input
+        .parse::<Pubkey>()
+        .map_err(|_| anyhow!(error_message.to_string()))
+}
 
-pub fn authorize(cfg_override: &ConfigOverride, world: String, new_authority: String) -> Result<()> {
+pub fn authorize(
+    cfg_override: &ConfigOverride,
+    world: String,
+    new_authority: String,
+) -> Result<()> {
     let world_pubkey = parse_pubkey(&world, "Invalid world public key")?;
     let new_authority_pubkey = parse_pubkey(&new_authority, "Invalid new authority public key")?;
 
@@ -60,9 +67,14 @@ pub fn authorize(cfg_override: &ConfigOverride, world: String, new_authority: St
     Ok(())
 }
 
-pub fn deauthorize(cfg_override: &ConfigOverride, world: String, authority_to_delete: String) -> Result<()> {
+pub fn deauthorize(
+    cfg_override: &ConfigOverride,
+    world: String,
+    authority_to_delete: String,
+) -> Result<()> {
     let world_pubkey = parse_pubkey(&world, "Invalid world public key")?;
-    let authority_to_delete_pubkey = parse_pubkey(&authority_to_delete, "Invalid authority public key")?;
+    let authority_to_delete_pubkey =
+        parse_pubkey(&authority_to_delete, "Invalid authority public key")?;
 
     let (client, payer) = setup_client(cfg_override)?;
     let program = client.program(ID)?;
@@ -92,7 +104,11 @@ pub fn deauthorize(cfg_override: &ConfigOverride, world: String, authority_to_de
     Ok(())
 }
 
-pub fn approve_system(cfg_override: &ConfigOverride, world: String, system_to_approve: String) -> Result<()> {
+pub fn approve_system(
+    cfg_override: &ConfigOverride,
+    world: String,
+    system_to_approve: String,
+) -> Result<()> {
     let world_pubkey = parse_pubkey(&world, "Invalid world public key")?;
     let system_to_approve_pubkey = parse_pubkey(&system_to_approve, "Invalid system public key")?;
 
@@ -119,7 +135,11 @@ pub fn approve_system(cfg_override: &ConfigOverride, world: String, system_to_ap
     Ok(())
 }
 
-pub fn remove_system(cfg_override: &ConfigOverride, world: String, system_to_remove: String) -> Result<()> {
+pub fn remove_system(
+    cfg_override: &ConfigOverride,
+    world: String,
+    system_to_remove: String,
+) -> Result<()> {
     let world_pubkey = parse_pubkey(&world, "Invalid world public key")?;
     let system_to_remove_pubkey = parse_pubkey(&system_to_remove, "Invalid system public key")?;
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -173,8 +173,12 @@ pub fn entry(opts: Opts) -> Result<()> {
             command.world,
             command.authority_to_remove,
         ),
-        BoltCommand::ApproveSystem(command) => approve_system(&opts.cfg_override, command.world, command.system_to_approve),
-        BoltCommand::RemoveSystem(command) => remove_system(&opts.cfg_override, command.world, command.system_to_remove)
+        BoltCommand::ApproveSystem(command) => {
+            approve_system(&opts.cfg_override, command.world, command.system_to_approve)
+        }
+        BoltCommand::RemoveSystem(command) => {
+            remove_system(&opts.cfg_override, command.world, command.system_to_remove)
+        }
     }
 }
 // Bolt Init

--- a/clients/bolt-sdk/package.json
+++ b/clients/bolt-sdk/package.json
@@ -37,7 +37,7 @@
   "main": "lib/index.js",
   "scripts": {
     "clean": "rimraf lib",
-    "build": "npm run clean && tsc && npm run lint:fix",
+    "build": "cp ../../target/types/world.ts src/generated/types/world.ts && cp ../../target/idl/world.json src/generated/idl/world.json && npm run clean && tsc && npm run lint:fix",
     "build:docs": "typedoc && typedoc --plugin typedoc-plugin-markdown --out docs-mk",
     "dev": "tsc --watch",
     "start": "tsc",

--- a/clients/bolt-sdk/src/generated/idl/world.json
+++ b/clients/bolt-sdk/src/generated/idl/world.json
@@ -632,6 +632,11 @@
       "code": 6003,
       "name": "AuthorityNotFound",
       "msg": "The provided authority not found"
+    },
+    {
+      "code": 6004,
+      "name": "SystemNotApproved",
+      "msg": "The system is not approved in this world instance"
     }
   ],
   "types": [

--- a/clients/bolt-sdk/src/generated/idl/world.json
+++ b/clients/bolt-sdk/src/generated/idl/world.json
@@ -1,0 +1,598 @@
+{
+  "address": "WorLD15A7CrDwLcLy4fRqtaTb9fbd8o8iqiEMUDse2n",
+  "metadata": {
+    "name": "world",
+    "version": "0.1.9",
+    "spec": "0.1.0",
+    "description": "Bolt World program",
+    "repository": "https://github.com/magicblock-labs/bolt"
+  },
+  "instructions": [
+    {
+      "name": "add_authority",
+      "discriminator": [
+        229,
+        9,
+        106,
+        73,
+        91,
+        213,
+        109,
+        183
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "new_authority"
+        },
+        {
+          "name": "world",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "world_id",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "add_entity",
+      "discriminator": [
+        163,
+        241,
+        57,
+        35,
+        244,
+        244,
+        48,
+        57
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "entity",
+          "writable": true
+        },
+        {
+          "name": "world",
+          "writable": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "extra_seed",
+          "type": {
+            "option": "string"
+          }
+        }
+      ]
+    },
+    {
+      "name": "apply",
+      "discriminator": [
+        248,
+        243,
+        145,
+        24,
+        105,
+        50,
+        162,
+        225
+      ],
+      "accounts": [
+        {
+          "name": "component_program"
+        },
+        {
+          "name": "bolt_system"
+        },
+        {
+          "name": "bolt_component",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "instruction_sysvar_account",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "apply2",
+      "discriminator": [
+        120,
+        32,
+        116,
+        154,
+        158,
+        159,
+        208,
+        73
+      ],
+      "accounts": [
+        {
+          "name": "bolt_system"
+        },
+        {
+          "name": "component_program_1"
+        },
+        {
+          "name": "bolt_component_1",
+          "writable": true
+        },
+        {
+          "name": "component_program_2"
+        },
+        {
+          "name": "bolt_component_2",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "instruction_sysvar_account",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "apply3",
+      "discriminator": [
+        254,
+        146,
+        49,
+        7,
+        236,
+        131,
+        105,
+        221
+      ],
+      "accounts": [
+        {
+          "name": "bolt_system"
+        },
+        {
+          "name": "component_program_1"
+        },
+        {
+          "name": "bolt_component_1",
+          "writable": true
+        },
+        {
+          "name": "component_program_2"
+        },
+        {
+          "name": "bolt_component_2",
+          "writable": true
+        },
+        {
+          "name": "component_program_3"
+        },
+        {
+          "name": "bolt_component_3",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "instruction_sysvar_account",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "apply4",
+      "discriminator": [
+        223,
+        104,
+        24,
+        79,
+        252,
+        196,
+        14,
+        109
+      ],
+      "accounts": [
+        {
+          "name": "bolt_system"
+        },
+        {
+          "name": "component_program_1"
+        },
+        {
+          "name": "bolt_component_1",
+          "writable": true
+        },
+        {
+          "name": "component_program_2"
+        },
+        {
+          "name": "bolt_component_2",
+          "writable": true
+        },
+        {
+          "name": "component_program_3"
+        },
+        {
+          "name": "bolt_component_3",
+          "writable": true
+        },
+        {
+          "name": "component_program_4"
+        },
+        {
+          "name": "bolt_component_4",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "instruction_sysvar_account",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "apply5",
+      "discriminator": [
+        70,
+        164,
+        214,
+        28,
+        136,
+        116,
+        84,
+        153
+      ],
+      "accounts": [
+        {
+          "name": "bolt_system"
+        },
+        {
+          "name": "component_program_1"
+        },
+        {
+          "name": "bolt_component_1",
+          "writable": true
+        },
+        {
+          "name": "component_program_2"
+        },
+        {
+          "name": "bolt_component_2",
+          "writable": true
+        },
+        {
+          "name": "component_program_3"
+        },
+        {
+          "name": "bolt_component_3",
+          "writable": true
+        },
+        {
+          "name": "component_program_4"
+        },
+        {
+          "name": "bolt_component_4",
+          "writable": true
+        },
+        {
+          "name": "component_program_5"
+        },
+        {
+          "name": "bolt_component_5",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "instruction_sysvar_account",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "initialize_component",
+      "discriminator": [
+        36,
+        143,
+        233,
+        113,
+        12,
+        234,
+        61,
+        30
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "data",
+          "writable": true
+        },
+        {
+          "name": "entity"
+        },
+        {
+          "name": "component_program"
+        },
+        {
+          "name": "authority"
+        },
+        {
+          "name": "instruction_sysvar_account",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize_new_world",
+      "discriminator": [
+        23,
+        96,
+        88,
+        194,
+        200,
+        203,
+        200,
+        98
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "world",
+          "writable": true
+        },
+        {
+          "name": "registry",
+          "writable": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize_registry",
+      "discriminator": [
+        189,
+        181,
+        20,
+        17,
+        174,
+        57,
+        249,
+        59
+      ],
+      "accounts": [
+        {
+          "name": "registry",
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "remove_authority",
+      "discriminator": [
+        242,
+        104,
+        208,
+        132,
+        190,
+        250,
+        74,
+        216
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "authority_to_delete"
+        },
+        {
+          "name": "world",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "world_id",
+          "type": "u64"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "Entity",
+      "discriminator": [
+        46,
+        157,
+        161,
+        161,
+        254,
+        46,
+        79,
+        24
+      ]
+    },
+    {
+      "name": "Registry",
+      "discriminator": [
+        47,
+        174,
+        110,
+        246,
+        184,
+        182,
+        252,
+        218
+      ]
+    },
+    {
+      "name": "World",
+      "discriminator": [
+        145,
+        45,
+        170,
+        174,
+        122,
+        32,
+        155,
+        124
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "InvalidAuthority",
+      "msg": "Invalid authority for instruction"
+    },
+    {
+      "code": 6001,
+      "name": "WorldAccountMismatch",
+      "msg": "The provided world account does not match the expected PDA."
+    },
+    {
+      "code": 6002,
+      "name": "TooManyAuthorities",
+      "msg": "Exceed the maximum number of authorities."
+    },
+    {
+      "code": 6003,
+      "name": "AuthorityNotFound",
+      "msg": "The provided authority not found"
+    }
+  ],
+  "types": [
+    {
+      "name": "Entity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "id",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Registry",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "worlds",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "World",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "id",
+            "type": "u64"
+          },
+          {
+            "name": "entities",
+            "type": "u64"
+          },
+          {
+            "name": "authorities",
+            "type": {
+              "vec": "pubkey"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/clients/bolt-sdk/src/generated/idl/world.json
+++ b/clients/bolt-sdk/src/generated/idl/world.json
@@ -32,6 +32,10 @@
         {
           "name": "world",
           "writable": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         }
       ],
       "args": [
@@ -111,6 +115,9 @@
         {
           "name": "instruction_sysvar_account",
           "address": "Sysvar1nstructions1111111111111111111111111"
+        },
+        {
+          "name": "world"
         }
       ],
       "args": [
@@ -157,6 +164,9 @@
         {
           "name": "instruction_sysvar_account",
           "address": "Sysvar1nstructions1111111111111111111111111"
+        },
+        {
+          "name": "world"
         }
       ],
       "args": [
@@ -210,6 +220,9 @@
         {
           "name": "instruction_sysvar_account",
           "address": "Sysvar1nstructions1111111111111111111111111"
+        },
+        {
+          "name": "world"
         }
       ],
       "args": [
@@ -270,6 +283,9 @@
         {
           "name": "instruction_sysvar_account",
           "address": "Sysvar1nstructions1111111111111111111111111"
+        },
+        {
+          "name": "world"
         }
       ],
       "args": [
@@ -337,6 +353,9 @@
         {
           "name": "instruction_sysvar_account",
           "address": "Sysvar1nstructions1111111111111111111111111"
+        },
+        {
+          "name": "world"
         }
       ],
       "args": [
@@ -345,6 +364,38 @@
           "type": "bytes"
         }
       ]
+    },
+    {
+      "name": "approve_system",
+      "discriminator": [
+        114,
+        165,
+        105,
+        68,
+        52,
+        67,
+        207,
+        121
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "world",
+          "writable": true
+        },
+        {
+          "name": "system"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
     },
     {
       "name": "initialize_component",
@@ -474,6 +525,10 @@
         {
           "name": "world",
           "writable": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         }
       ],
       "args": [
@@ -482,6 +537,38 @@
           "type": "u64"
         }
       ]
+    },
+    {
+      "name": "remove_system",
+      "discriminator": [
+        218,
+        80,
+        71,
+        80,
+        161,
+        130,
+        149,
+        120
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "world",
+          "writable": true
+        },
+        {
+          "name": "system"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
     }
   ],
   "accounts": [
@@ -590,6 +677,14 @@
             "type": {
               "vec": "pubkey"
             }
+          },
+          {
+            "name": "permissionless",
+            "type": "bool"
+          },
+          {
+            "name": "systems",
+            "type": "bytes"
           }
         ]
       }

--- a/clients/bolt-sdk/src/generated/index.ts
+++ b/clients/bolt-sdk/src/generated/index.ts
@@ -6,6 +6,8 @@
  */
 
 import { PublicKey } from "@solana/web3.js";
+import { type World as WorldProgram } from "./types/world";
+import idl from "./idl/world.json";
 export * from "./accounts";
 export * from "./errors";
 export * from "./instructions";
@@ -25,3 +27,6 @@ export const PROGRAM_ADDRESS = "WorLD15A7CrDwLcLy4fRqtaTb9fbd8o8iqiEMUDse2n";
  * @category generated
  */
 export const PROGRAM_ID = new PublicKey(PROGRAM_ADDRESS);
+
+export default WorldProgram;
+export { idl as worldIdl };

--- a/clients/bolt-sdk/src/generated/types/world.ts
+++ b/clients/bolt-sdk/src/generated/types/world.ts
@@ -1,0 +1,478 @@
+/**
+ * Program IDL in camelCase format in order to be used in JS/TS.
+ *
+ * Note that this is only a type helper and is not the actual IDL. The original
+ * IDL can be found at `target/idl/world.json`.
+ */
+export interface World {
+  address: "WorLD15A7CrDwLcLy4fRqtaTb9fbd8o8iqiEMUDse2n";
+  metadata: {
+    name: "world";
+    version: "0.1.9";
+    spec: "0.1.0";
+    description: "Bolt World program";
+    repository: "https://github.com/magicblock-labs/bolt";
+  };
+  instructions: [
+    {
+      name: "addAuthority";
+      discriminator: [229, 9, 106, 73, 91, 213, 109, 183];
+      accounts: [
+        {
+          name: "authority";
+          writable: true;
+          signer: true;
+        },
+        {
+          name: "newAuthority";
+        },
+        {
+          name: "world";
+          writable: true;
+        }
+      ];
+      args: [
+        {
+          name: "worldId";
+          type: "u64";
+        }
+      ];
+    },
+    {
+      name: "addEntity";
+      discriminator: [163, 241, 57, 35, 244, 244, 48, 57];
+      accounts: [
+        {
+          name: "payer";
+          writable: true;
+          signer: true;
+        },
+        {
+          name: "entity";
+          writable: true;
+        },
+        {
+          name: "world";
+          writable: true;
+        },
+        {
+          name: "systemProgram";
+          address: "11111111111111111111111111111111";
+        }
+      ];
+      args: [
+        {
+          name: "extraSeed";
+          type: {
+            option: "string";
+          };
+        }
+      ];
+    },
+    {
+      name: "apply";
+      discriminator: [248, 243, 145, 24, 105, 50, 162, 225];
+      accounts: [
+        {
+          name: "componentProgram";
+        },
+        {
+          name: "boltSystem";
+        },
+        {
+          name: "boltComponent";
+          writable: true;
+        },
+        {
+          name: "authority";
+          signer: true;
+        },
+        {
+          name: "instructionSysvarAccount";
+          address: "Sysvar1nstructions1111111111111111111111111";
+        }
+      ];
+      args: [
+        {
+          name: "args";
+          type: "bytes";
+        }
+      ];
+    },
+    {
+      name: "apply2";
+      discriminator: [120, 32, 116, 154, 158, 159, 208, 73];
+      accounts: [
+        {
+          name: "boltSystem";
+        },
+        {
+          name: "componentProgram1";
+        },
+        {
+          name: "boltComponent1";
+          writable: true;
+        },
+        {
+          name: "componentProgram2";
+        },
+        {
+          name: "boltComponent2";
+          writable: true;
+        },
+        {
+          name: "authority";
+          signer: true;
+        },
+        {
+          name: "instructionSysvarAccount";
+          address: "Sysvar1nstructions1111111111111111111111111";
+        }
+      ];
+      args: [
+        {
+          name: "args";
+          type: "bytes";
+        }
+      ];
+    },
+    {
+      name: "apply3";
+      discriminator: [254, 146, 49, 7, 236, 131, 105, 221];
+      accounts: [
+        {
+          name: "boltSystem";
+        },
+        {
+          name: "componentProgram1";
+        },
+        {
+          name: "boltComponent1";
+          writable: true;
+        },
+        {
+          name: "componentProgram2";
+        },
+        {
+          name: "boltComponent2";
+          writable: true;
+        },
+        {
+          name: "componentProgram3";
+        },
+        {
+          name: "boltComponent3";
+          writable: true;
+        },
+        {
+          name: "authority";
+          signer: true;
+        },
+        {
+          name: "instructionSysvarAccount";
+          address: "Sysvar1nstructions1111111111111111111111111";
+        }
+      ];
+      args: [
+        {
+          name: "args";
+          type: "bytes";
+        }
+      ];
+    },
+    {
+      name: "apply4";
+      discriminator: [223, 104, 24, 79, 252, 196, 14, 109];
+      accounts: [
+        {
+          name: "boltSystem";
+        },
+        {
+          name: "componentProgram1";
+        },
+        {
+          name: "boltComponent1";
+          writable: true;
+        },
+        {
+          name: "componentProgram2";
+        },
+        {
+          name: "boltComponent2";
+          writable: true;
+        },
+        {
+          name: "componentProgram3";
+        },
+        {
+          name: "boltComponent3";
+          writable: true;
+        },
+        {
+          name: "componentProgram4";
+        },
+        {
+          name: "boltComponent4";
+          writable: true;
+        },
+        {
+          name: "authority";
+          signer: true;
+        },
+        {
+          name: "instructionSysvarAccount";
+          address: "Sysvar1nstructions1111111111111111111111111";
+        }
+      ];
+      args: [
+        {
+          name: "args";
+          type: "bytes";
+        }
+      ];
+    },
+    {
+      name: "apply5";
+      discriminator: [70, 164, 214, 28, 136, 116, 84, 153];
+      accounts: [
+        {
+          name: "boltSystem";
+        },
+        {
+          name: "componentProgram1";
+        },
+        {
+          name: "boltComponent1";
+          writable: true;
+        },
+        {
+          name: "componentProgram2";
+        },
+        {
+          name: "boltComponent2";
+          writable: true;
+        },
+        {
+          name: "componentProgram3";
+        },
+        {
+          name: "boltComponent3";
+          writable: true;
+        },
+        {
+          name: "componentProgram4";
+        },
+        {
+          name: "boltComponent4";
+          writable: true;
+        },
+        {
+          name: "componentProgram5";
+        },
+        {
+          name: "boltComponent5";
+          writable: true;
+        },
+        {
+          name: "authority";
+          signer: true;
+        },
+        {
+          name: "instructionSysvarAccount";
+          address: "Sysvar1nstructions1111111111111111111111111";
+        }
+      ];
+      args: [
+        {
+          name: "args";
+          type: "bytes";
+        }
+      ];
+    },
+    {
+      name: "initializeComponent";
+      discriminator: [36, 143, 233, 113, 12, 234, 61, 30];
+      accounts: [
+        {
+          name: "payer";
+          writable: true;
+          signer: true;
+        },
+        {
+          name: "data";
+          writable: true;
+        },
+        {
+          name: "entity";
+        },
+        {
+          name: "componentProgram";
+        },
+        {
+          name: "authority";
+        },
+        {
+          name: "instructionSysvarAccount";
+          address: "Sysvar1nstructions1111111111111111111111111";
+        },
+        {
+          name: "systemProgram";
+          address: "11111111111111111111111111111111";
+        }
+      ];
+      args: [];
+    },
+    {
+      name: "initializeNewWorld";
+      discriminator: [23, 96, 88, 194, 200, 203, 200, 98];
+      accounts: [
+        {
+          name: "payer";
+          writable: true;
+          signer: true;
+        },
+        {
+          name: "world";
+          writable: true;
+        },
+        {
+          name: "registry";
+          writable: true;
+        },
+        {
+          name: "systemProgram";
+          address: "11111111111111111111111111111111";
+        }
+      ];
+      args: [];
+    },
+    {
+      name: "initializeRegistry";
+      discriminator: [189, 181, 20, 17, 174, 57, 249, 59];
+      accounts: [
+        {
+          name: "registry";
+          writable: true;
+        },
+        {
+          name: "payer";
+          writable: true;
+          signer: true;
+        },
+        {
+          name: "systemProgram";
+          address: "11111111111111111111111111111111";
+        }
+      ];
+      args: [];
+    },
+    {
+      name: "removeAuthority";
+      discriminator: [242, 104, 208, 132, 190, 250, 74, 216];
+      accounts: [
+        {
+          name: "authority";
+          writable: true;
+          signer: true;
+        },
+        {
+          name: "authorityToDelete";
+        },
+        {
+          name: "world";
+          writable: true;
+        }
+      ];
+      args: [
+        {
+          name: "worldId";
+          type: "u64";
+        }
+      ];
+    }
+  ];
+  accounts: [
+    {
+      name: "entity";
+      discriminator: [46, 157, 161, 161, 254, 46, 79, 24];
+    },
+    {
+      name: "registry";
+      discriminator: [47, 174, 110, 246, 184, 182, 252, 218];
+    },
+    {
+      name: "world";
+      discriminator: [145, 45, 170, 174, 122, 32, 155, 124];
+    }
+  ];
+  errors: [
+    {
+      code: 6000;
+      name: "invalidAuthority";
+      msg: "Invalid authority for instruction";
+    },
+    {
+      code: 6001;
+      name: "worldAccountMismatch";
+      msg: "The provided world account does not match the expected PDA.";
+    },
+    {
+      code: 6002;
+      name: "tooManyAuthorities";
+      msg: "Exceed the maximum number of authorities.";
+    },
+    {
+      code: 6003;
+      name: "authorityNotFound";
+      msg: "The provided authority not found";
+    }
+  ];
+  types: [
+    {
+      name: "entity";
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "id";
+            type: "u64";
+          }
+        ];
+      };
+    },
+    {
+      name: "registry";
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "worlds";
+            type: "u64";
+          }
+        ];
+      };
+    },
+    {
+      name: "world";
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "id";
+            type: "u64";
+          },
+          {
+            name: "entities";
+            type: "u64";
+          },
+          {
+            name: "authorities";
+            type: {
+              vec: "pubkey";
+            };
+          }
+        ];
+      };
+    }
+  ];
+}

--- a/clients/bolt-sdk/src/generated/types/world.ts
+++ b/clients/bolt-sdk/src/generated/types/world.ts
@@ -29,6 +29,10 @@ export interface World {
         {
           name: "world";
           writable: true;
+        },
+        {
+          name: "systemProgram";
+          address: "11111111111111111111111111111111";
         }
       ];
       args: [
@@ -90,6 +94,9 @@ export interface World {
         {
           name: "instructionSysvarAccount";
           address: "Sysvar1nstructions1111111111111111111111111";
+        },
+        {
+          name: "world";
         }
       ];
       args: [
@@ -127,6 +134,9 @@ export interface World {
         {
           name: "instructionSysvarAccount";
           address: "Sysvar1nstructions1111111111111111111111111";
+        },
+        {
+          name: "world";
         }
       ];
       args: [
@@ -171,6 +181,9 @@ export interface World {
         {
           name: "instructionSysvarAccount";
           address: "Sysvar1nstructions1111111111111111111111111";
+        },
+        {
+          name: "world";
         }
       ];
       args: [
@@ -222,6 +235,9 @@ export interface World {
         {
           name: "instructionSysvarAccount";
           address: "Sysvar1nstructions1111111111111111111111111";
+        },
+        {
+          name: "world";
         }
       ];
       args: [
@@ -280,6 +296,9 @@ export interface World {
         {
           name: "instructionSysvarAccount";
           address: "Sysvar1nstructions1111111111111111111111111";
+        },
+        {
+          name: "world";
         }
       ];
       args: [
@@ -288,6 +307,29 @@ export interface World {
           type: "bytes";
         }
       ];
+    },
+    {
+      name: "approveSystem";
+      discriminator: [114, 165, 105, 68, 52, 67, 207, 121];
+      accounts: [
+        {
+          name: "authority";
+          writable: true;
+          signer: true;
+        },
+        {
+          name: "world";
+          writable: true;
+        },
+        {
+          name: "system";
+        },
+        {
+          name: "systemProgram";
+          address: "11111111111111111111111111111111";
+        }
+      ];
+      args: [];
     },
     {
       name: "initializeComponent";
@@ -381,6 +423,10 @@ export interface World {
         {
           name: "world";
           writable: true;
+        },
+        {
+          name: "systemProgram";
+          address: "11111111111111111111111111111111";
         }
       ];
       args: [
@@ -389,6 +435,29 @@ export interface World {
           type: "u64";
         }
       ];
+    },
+    {
+      name: "removeSystem";
+      discriminator: [218, 80, 71, 80, 161, 130, 149, 120];
+      accounts: [
+        {
+          name: "authority";
+          writable: true;
+          signer: true;
+        },
+        {
+          name: "world";
+          writable: true;
+        },
+        {
+          name: "system";
+        },
+        {
+          name: "systemProgram";
+          address: "11111111111111111111111111111111";
+        }
+      ];
+      args: [];
     }
   ];
   accounts: [
@@ -470,6 +539,14 @@ export interface World {
             type: {
               vec: "pubkey";
             };
+          },
+          {
+            name: "permissionless";
+            type: "bool";
+          },
+          {
+            name: "systems";
+            type: "bytes";
           }
         ];
       };

--- a/clients/bolt-sdk/src/generated/types/world.ts
+++ b/clients/bolt-sdk/src/generated/types/world.ts
@@ -494,6 +494,11 @@ export interface World {
       code: 6003;
       name: "authorityNotFound";
       msg: "The provided authority not found";
+    },
+    {
+      code: 6004;
+      name: "systemNotApproved";
+      msg: "The system is not approved in this world instance";
     }
   ];
   types: [

--- a/clients/bolt-sdk/src/world/transactions.ts
+++ b/clients/bolt-sdk/src/world/transactions.ts
@@ -148,6 +148,78 @@ export async function RemoveAuthority({
 }
 
 /**
+ * Create the transaction to Approve a system
+ * @param authority
+ * @param systemToApprove
+ * @param world
+ * @constructor
+ */
+export async function ApproveSystem({
+  authority,
+  systemToApprove,
+  world,
+}: {
+  authority: PublicKey;
+  systemToApprove: PublicKey;
+  world: PublicKey;
+}): Promise<{
+  instruction: TransactionInstruction;
+  transaction: Transaction;
+}> {
+  const program = new Program(
+    worldIdl as Idl
+  ) as unknown as Program<WorldProgram>;
+  const approveSystemIx = await program.methods
+    .approveSystem()
+    .accounts({
+      authority,
+      system: systemToApprove,
+      world,
+    })
+    .instruction();
+  return {
+    instruction: approveSystemIx,
+    transaction: new Transaction().add(approveSystemIx),
+  };
+}
+
+/**
+ * Create the transaction to Remove a system
+ * @param authority
+ * @param systemToRemove
+ * @param world
+ * @constructor
+ */
+export async function RemoveSystem({
+  authority,
+  systemToRemove,
+  world,
+}: {
+  authority: PublicKey;
+  systemToRemove: PublicKey;
+  world: PublicKey;
+}): Promise<{
+  instruction: TransactionInstruction;
+  transaction: Transaction;
+}> {
+  const program = new Program(
+    worldIdl as Idl
+  ) as unknown as Program<WorldProgram>;
+  const removeSystemIx = await program.methods
+    .removeSystem()
+    .accounts({
+      authority,
+      system: systemToRemove,
+      world,
+    })
+    .instruction();
+  return {
+    instruction: removeSystemIx,
+    transaction: new Transaction().add(removeSystemIx),
+  };
+}
+
+/**
  * Create the transaction to Add a new entity
  * @param payer
  * @param worldPda
@@ -262,6 +334,9 @@ function createApplySystemInstruction({
   extraAccounts,
   args,
 }: ApplySystemInstruction): web3.TransactionInstruction {
+  const program = new Program(
+    worldIdl as Idl
+  ) as unknown as Program<WorldProgram>;
   let componentCount = 0;
   entities.forEach(function (entity) {
     componentCount += entity.components.length;

--- a/clients/bolt-sdk/src/world/transactions.ts
+++ b/clients/bolt-sdk/src/world/transactions.ts
@@ -24,7 +24,9 @@ import {
   Transaction,
   type TransactionInstruction,
 } from "@solana/web3.js";
-import { PROGRAM_ID } from "../generated";
+import type WorldProgram from "../generated";
+import { PROGRAM_ID, worldIdl } from "../generated";
+import { type Idl, Program } from "@coral-xyz/anchor";
 
 const MAX_COMPONENTS = 5;
 
@@ -60,6 +62,88 @@ export async function InitializeNewWorld({
     transaction: new Transaction().add(initializeWorldIx),
     worldPda,
     worldId,
+  };
+}
+
+/**
+ * Create the transaction to Add a new authority
+ * @param authority
+ * @param newAuthority
+ * @param world
+ * @param connection
+ * @constructor
+ */
+export async function AddAuthority({
+  authority,
+  newAuthority,
+  world,
+  connection,
+}: {
+  authority: PublicKey;
+  newAuthority: PublicKey;
+  world: PublicKey;
+  connection: Connection;
+}): Promise<{
+  instruction: TransactionInstruction;
+  transaction: Transaction;
+}> {
+  const program = new Program(
+    worldIdl as Idl
+  ) as unknown as Program<WorldProgram>;
+  const worldInstance = await World.fromAccountAddress(connection, world);
+  const worldId = new BN(worldInstance.id);
+  const addAuthorityIx = await program.methods
+    .addAuthority(worldId)
+    .accounts({
+      authority,
+      newAuthority,
+      world,
+    })
+    .instruction();
+  return {
+    instruction: addAuthorityIx,
+    transaction: new Transaction().add(addAuthorityIx),
+  };
+}
+
+/**
+ * Create the transaction to Remove an authority
+ * @param authority
+ * @param authorityToDelete
+ * @param world
+ * @param connection
+ * @constructor
+ */
+export async function RemoveAuthority({
+  authority,
+  authorityToDelete,
+  world,
+  connection,
+}: {
+  authority: PublicKey;
+  authorityToDelete: PublicKey;
+  world: PublicKey;
+  connection: Connection;
+}): Promise<{
+  instruction: TransactionInstruction;
+  transaction: Transaction;
+}> {
+  const program = new Program(
+    worldIdl as Idl
+  ) as unknown as Program<WorldProgram>;
+  const worldInstance = await World.fromAccountAddress(connection, world);
+  const worldId = new BN(worldInstance.id);
+  const removeAuthorityIx = await program.methods
+    .removeAuthority(worldId)
+    .accounts({
+      authority,
+      authorityToDelete,
+      world,
+    })
+    .instruction();
+  return {
+    instruction: removeAuthorityIx,
+    transaction: new Transaction().add(removeAuthorityIx),
   };
 }
 

--- a/crates/bolt-helpers/attribute/world-apply/src/lib.rs
+++ b/crates/bolt-helpers/attribute/world-apply/src/lib.rs
@@ -96,6 +96,8 @@ pub fn apply_system(attr: TokenStream, item: TokenStream) -> TokenStream {
                 #[account(address = anchor_lang::solana_program::sysvar::instructions::id())]
                 /// CHECK: instruction sysvar check
                 pub instruction_sysvar_account: UncheckedAccount<'info>,
+                #[account()]
+                pub world: Account<'info, World>,
             }
         };
         quote! {

--- a/programs/world/src/error.rs
+++ b/programs/world/src/error.rs
@@ -6,4 +6,8 @@ pub enum WorldError {
     InvalidAuthority,
     #[msg("The provided world account does not match the expected PDA.")]
     WorldAccountMismatch,
+    #[msg("Exceed the maximum number of authorities.")]
+    TooManyAuthorities,
+    #[msg("The provided authority not found")]
+    AuthorityNotFound,
 }

--- a/programs/world/src/error.rs
+++ b/programs/world/src/error.rs
@@ -10,4 +10,6 @@ pub enum WorldError {
     TooManyAuthorities,
     #[msg("The provided authority not found")]
     AuthorityNotFound,
+    #[msg("The system is not approved in this world instance")]
+    SystemNotApproved,
 }

--- a/programs/world/src/lib.rs
+++ b/programs/world/src/lib.rs
@@ -39,15 +39,17 @@ pub mod world {
 
     #[allow(unused_variables)]
     pub fn add_authority(ctx: Context<AddAuthority>, world_id: u64) -> Result<()> {
-        if ctx.accounts.world.authorities.len() == 3 {
-            return Err(WorldError::TooManyAuthorities.into());
-        }
         if ctx.accounts.world.authorities.is_empty()
-            || ctx
+            || (ctx
                 .accounts
                 .world
                 .authorities
                 .contains(ctx.accounts.authority.key)
+                && !ctx
+                    .accounts
+                    .world
+                    .authorities
+                    .contains(ctx.accounts.new_authority.key))
         {
             ctx.accounts
                 .world
@@ -216,6 +218,10 @@ pub mod world {
             ctx.accounts.world.authorities.len(),
             encoded_world_systems.len(),
         );
+
+        if world_systems.approved_systems.is_empty() {
+            ctx.accounts.world.permissionless = true;
+        }
 
         // Remove the extra rent
         let rent = Rent::get()?;

--- a/programs/world/src/lib.rs
+++ b/programs/world/src/lib.rs
@@ -1,5 +1,6 @@
 use anchor_lang::prelude::*;
 use bolt_helpers_world_apply::apply_system;
+use std::collections::BTreeSet;
 use tuple_conv::RepeatedTuple;
 
 #[cfg(not(feature = "no-entrypoint"))]
@@ -51,6 +52,31 @@ pub mod world {
                 .world
                 .authorities
                 .push(*ctx.accounts.new_authority.key);
+
+            let new_space = World::space_for_authorities(
+                ctx.accounts.world.authorities.len(),
+                ctx.accounts.world.systems.len(),
+            );
+
+            // Transfer to make it rent exempt
+            let rent = Rent::get()?;
+            let new_minimum_balance = rent.minimum_balance(new_space);
+            let lamports_diff = new_minimum_balance.saturating_sub(ctx.accounts.world.to_account_info().lamports());
+            if lamports_diff > 0 {
+                anchor_lang::solana_program::program::invoke(
+                    &anchor_lang::solana_program::system_instruction::transfer(
+                        ctx.accounts.authority.key,
+                        ctx.accounts.world.to_account_info().key,
+                        lamports_diff
+                    ),
+                    &[
+                        ctx.accounts.authority.to_account_info(),
+                        ctx.accounts.world.to_account_info(),
+                        ctx.accounts.system_program.to_account_info(),
+                    ],
+                )?;
+            }
+            ctx.accounts.world.to_account_info().realloc(new_space, false)?;
         }
         Ok(())
     }
@@ -73,10 +99,109 @@ pub mod world {
             .position(|&x| x == *ctx.accounts.authority_to_delete.key)
         {
             ctx.accounts.world.authorities.remove(index);
+
+            let new_space = World::space_for_authorities(
+                ctx.accounts.world.authorities.len(),
+                ctx.accounts.world.systems.len(),
+            );
+
+            // Remove the extra rent
+            let rent = Rent::get()?;
+            let new_minimum_balance = rent.minimum_balance(new_space);
+            let lamports_diff = new_minimum_balance.saturating_sub(ctx.accounts.world.to_account_info().lamports());
+            **ctx.accounts.world.to_account_info().try_borrow_mut_lamports()? += lamports_diff;
+            **ctx.accounts.authority.to_account_info().try_borrow_mut_lamports()? -= lamports_diff;
+            ctx.accounts.world.to_account_info().realloc(new_space, false)?;
             Ok(())
         } else {
             Err(WorldError::AuthorityNotFound.into())
         }
+    }
+
+    pub fn approve_system(ctx: Context<ApproveSystem>) -> Result<()> {
+        if !ctx.accounts.authority.is_signer {
+            return Err(WorldError::InvalidAuthority.into());
+        }
+        if !ctx
+            .accounts
+            .world
+            .authorities
+            .contains(ctx.accounts.authority.key)
+        {
+            return Err(WorldError::InvalidAuthority.into());
+        }
+        if ctx.accounts.world.permissionless {
+            ctx.accounts.world.permissionless = false;
+        }
+
+        let mut world_systems = WorldSystems::try_from_slice(ctx.accounts.world.systems.as_ref()).unwrap_or_default();
+        world_systems.approved_systems.insert(ctx.accounts.system.key());
+
+        let encoded_world_systems = world_systems.try_to_vec()?;
+        ctx.accounts.world.systems = encoded_world_systems.clone();
+
+        let new_space = World::space_for_authorities(
+            ctx.accounts.world.authorities.len(),
+            encoded_world_systems.len(),
+        );
+
+        // Transfer to make it rent exempt
+        let rent = Rent::get()?;
+        let new_minimum_balance = rent.minimum_balance(new_space);
+        let lamports_diff = new_minimum_balance.saturating_sub(ctx.accounts.world.to_account_info().lamports());
+        if lamports_diff > 0 {
+            anchor_lang::solana_program::program::invoke(
+                &anchor_lang::solana_program::system_instruction::transfer(
+                    ctx.accounts.authority.key,
+                    ctx.accounts.world.to_account_info().key,
+                    lamports_diff
+                ),
+                &[
+                    ctx.accounts.authority.to_account_info(),
+                    ctx.accounts.world.to_account_info(),
+                    ctx.accounts.system_program.to_account_info(),
+                ],
+            )?;
+        }
+        ctx.accounts.world.to_account_info().realloc(new_space, false)?;
+        msg!("Approved system: {:?}", world_systems);
+        Ok(())
+    }
+
+
+    pub fn remove_system(ctx: Context<RemoveSystem>) -> Result<()> {
+        if !ctx.accounts.authority.is_signer {
+            return Err(WorldError::InvalidAuthority.into());
+        }
+        if !ctx
+            .accounts
+            .world
+            .authorities
+            .contains(ctx.accounts.authority.key)
+        {
+            return Err(WorldError::InvalidAuthority.into());
+        }
+
+        let mut world_systems = WorldSystems::try_from_slice(ctx.accounts.world.systems.as_ref()).unwrap_or_default();
+        world_systems.approved_systems.remove(&ctx.accounts.system.key());
+
+        let encoded_world_systems = world_systems.try_to_vec()?;
+        ctx.accounts.world.systems = encoded_world_systems.clone();
+
+        let new_space = World::space_for_authorities(
+            ctx.accounts.world.authorities.len(),
+            encoded_world_systems.len(),
+        );
+
+        // Remove the extra rent
+        let rent = Rent::get()?;
+        let new_minimum_balance = rent.minimum_balance(new_space);
+        let lamports_diff = new_minimum_balance.saturating_sub(ctx.accounts.world.to_account_info().lamports());
+        **ctx.accounts.world.to_account_info().try_borrow_mut_lamports()? += lamports_diff;
+        **ctx.accounts.authority.to_account_info().try_borrow_mut_lamports()? -= lamports_diff;
+        ctx.accounts.world.to_account_info().realloc(new_space, false)?;
+        msg!("Approved system: {:?}", world_systems);
+        Ok(())
     }
 
     #[allow(unused_variables)]
@@ -139,6 +264,8 @@ pub mod world {
         #[account(address = anchor_lang::solana_program::sysvar::instructions::id())]
         /// CHECK: instruction sysvar check
         pub instruction_sysvar_account: UncheckedAccount<'info>,
+        #[account()]
+        pub world: Account<'info, World>,
     }
 
     impl<'info> ApplySystem<'info> {
@@ -185,6 +312,7 @@ pub struct AddAuthority<'info> {
     pub new_authority: AccountInfo<'info>,
     #[account(mut, seeds = [World::seed(), &world_id.to_be_bytes()], bump)]
     pub world: Account<'info, World>,
+    pub system_program: Program<'info, System>,
 }
 
 #[derive(Accounts)]
@@ -197,6 +325,29 @@ pub struct RemoveAuthority<'info> {
     pub authority_to_delete: AccountInfo<'info>,
     #[account(mut, seeds = [World::seed(), &world_id.to_be_bytes()], bump)]
     pub world: Account<'info, World>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct ApproveSystem<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    #[account(mut)]
+    pub world: Account<'info, World>,
+    /// CHECK: Used for the pda derivation
+    pub system: AccountInfo<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct RemoveSystem<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    #[account(mut)]
+    pub world: Account<'info, World>,
+    /// CHECK: Used for the pda derivation
+    pub system: AccountInfo<'info>,
+    pub system_program: Program<'info, System>,
 }
 
 #[derive(Accounts)]
@@ -277,12 +428,41 @@ impl Registry {
 }
 
 #[account]
-#[derive(InitSpace, Default)]
+#[derive(Debug)]
 pub struct World {
     pub id: u64,
     pub entities: u64,
-    #[max_len(3)]
     pub authorities: Vec<Pubkey>,
+    pub permissionless: bool,
+    pub systems: Vec<u8>,
+}
+
+impl Default for World {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            entities: 0,
+            authorities: Vec::new(),
+            permissionless: true,
+            systems: Vec::new(),
+        }
+    }
+}
+
+impl World {
+    fn space_for_authorities(auths: usize, systems_space: usize) -> usize {
+        16 + 8 + 32 * auths + 1 + 8 + systems_space
+    }
+}
+
+#[derive(
+    anchor_lang::prelude::borsh::BorshSerialize,
+    anchor_lang::prelude::borsh::BorshDeserialize,
+    Default,
+    Debug
+)]
+pub struct WorldSystems {
+    pub approved_systems: BTreeSet<Pubkey>,
 }
 
 impl World {
@@ -291,7 +471,7 @@ impl World {
     }
 
     pub fn size() -> usize {
-        8 + World::INIT_SPACE
+        16 + 8 + 1 + 8
     }
 
     pub fn pda(&self) -> (Pubkey, u8) {
@@ -308,6 +488,20 @@ pub struct Entity {
 impl Entity {
     pub fn seed() -> &'static [u8] {
         b"entity"
+    }
+}
+
+#[account]
+#[derive(InitSpace, Default)]
+pub struct SystemWhitelist {}
+
+impl SystemWhitelist {
+    pub fn seed() -> &'static [u8] {
+        b"whitelist"
+    }
+
+    pub fn size() -> usize {
+        8 + Registry::INIT_SPACE
     }
 }
 

--- a/programs/world/src/lib.rs
+++ b/programs/world/src/lib.rs
@@ -57,7 +57,12 @@ pub mod world {
 
     #[allow(unused_variables)]
     pub fn remove_authority(ctx: Context<RemoveAuthority>, world_id: u64) -> Result<()> {
-        if !ctx.accounts.world.authorities.contains(ctx.accounts.authority.key) {
+        if !ctx
+            .accounts
+            .world
+            .authorities
+            .contains(ctx.accounts.authority.key)
+        {
             return Err(WorldError::InvalidAuthority.into());
         }
         if let Some(index) = ctx

--- a/programs/world/src/lib.rs
+++ b/programs/world/src/lib.rs
@@ -272,8 +272,6 @@ pub mod world {
         if !ctx.accounts.authority.is_signer && ctx.accounts.authority.key != &ID {
             return Err(WorldError::InvalidAuthority.into());
         }
-        msg!("Applying system");
-        msg!("Permisionless: {:?}", ctx.accounts.world.permissionless);
         if !ctx.accounts.world.permissionless
             && !ctx
                 .accounts

--- a/tests/bolt.ts
+++ b/tests/bolt.ts
@@ -104,7 +104,7 @@ describe("bolt", () => {
 
   const secondAuthority = Keypair.generate().publicKey;
 
-  it("InitializeRegistry", async () => {
+  it.only("InitializeRegistry", async () => {
     const registryPda = FindRegistryPda({});
     const initializeRegistryIx = createInitializeRegistryInstruction({
       registry: registryPda,
@@ -114,12 +114,13 @@ describe("bolt", () => {
     await provider.sendAndConfirm(tx);
   });
 
-  it("InitializeNewWorld", async () => {
+  it.only("InitializeNewWorld", async () => {
     const initializeNewWorld = await InitializeNewWorld({
       payer: provider.wallet.publicKey,
       connection: provider.connection,
     });
-    await provider.sendAndConfirm(initializeNewWorld.transaction);
+    const signature = await provider.sendAndConfirm(initializeNewWorld.transaction);
+    console.log("InitializeNewWorld signature: ", signature);
     worldPda = initializeNewWorld.worldPda; // Saved for later
   });
 


### PR DESCRIPTION
# Add authority approval/removal for world instances

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | Yes | #8  |

## Problem

- Systems where completely permissionless
- Added a way to add/remove authorities authorities on a world instance
- Adde a mechanism to approve/remove systems allows in a specific game instance

See #8 for a full description 

## Examples using the Bolt CLI

Authorize a new authority
```bash
bolt authorize JBupPMmv4zaXa5c8EdubsCPvoHZwCK7mwnDfmfs8dC5Y tEsT3eV6RFCWs1BZ7AXTzasHqTtMnMLCB2tjQ42TDXD
```

Deauthorize an authority
```bash
bolt deauthorize JBupPMmv4zaXa5c8EdubsCPvoHZwCK7mwnDfmfs8dC5Y tEsT3eV6RFCWs1BZ7AXTzasHqTtMnMLCB2tjQ42TDXD
```

Approve an authority using a specific key
```bash
bolt authorize JBupPMmv4zaXa5c8EdubsCPvoHZwCK7mwnDfmfs8dC5Y tEsT3eV6RFCWs1BZ7AXTzasHqTtMnMLCB2tjQ42TDXD --provider.wallet keypair.json
```

Approve a system
```bash
bolt approve-system JBupPMmv4zaXa5c8EdubsCPvoHZwCK7mwnDfmfs8dC5Y 6LHhFVwif6N9Po3jHtSmMVtPjF6zRfL3xMosSzcrQAS8
```

Remove a system
```bash
bolt authorize JBupPMmv4zaXa5c8EdubsCPvoHZwCK7mwnDfmfs8dC5Y 6LHhFVwif6N9Po3jHtSmMVtPjF6zRfL3xMosSzcrQAS8
```

## Notes

- PDAs can also be authorities, multisig, DAOs or outcome of a prediction market decision could approve/remove a system

## Issues

Closes #8 