### PR TITLE
:recycle: Fixing test template, broken after code refactor

### DIFF
--- a/cli/src/templates/workspace.rs
+++ b/cli/src/templates/workspace.rs
@@ -233,6 +233,7 @@ describe("{}", () => {{
     const applySystem = await ApplySystem({{
       authority: provider.wallet.publicKey,
       systemId: systemMovement.programId,
+      world: worldPda,
       entities: [{{
         entity: entityPda,
         components: [{{ componentId: positionComponent.programId }}],


### PR DESCRIPTION
## Problem

`ApplySystem` now takes `world` as a parameter. The test template code wasn't updated to do so.