### PR TITLE
feat: add missing apply function in sdk

### DIFF
--- a/clients/bolt-sdk/src/world/transactions.ts
+++ b/clients/bolt-sdk/src/world/transactions.ts
@@ -1,4 +1,5 @@
 import {
+  createApplyInstruction,
   createAddEntityInstruction,
   createInitializeComponentInstruction,
   createInitializeNewWorldInstruction,
@@ -300,6 +301,40 @@ export async function InitializeComponent({
     instruction: initializeComponentIx,
     transaction: new Transaction().add(initializeComponentIx),
     componentPda,
+  };
+}
+
+export async function Apply({
+  authority,
+  boltSystem,
+  boltComponent,
+  componentProgram,
+  anchorRemainingAccounts,
+  args
+}: {
+  authority: PublicKey;
+  boltSystem: PublicKey;
+  boltComponent: PublicKey;
+  componentProgram: PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
+  args: Uint8Array;
+}): Promise<{
+  instruction: TransactionInstruction;
+  transaction: Transaction;
+}> {
+  const initializeComponentIx = createApplyInstruction({
+    authority,
+    boltSystem,
+    boltComponent,
+    componentProgram,
+    instructionSysvarAccount: SYSVAR_INSTRUCTIONS_PUBKEY,
+    anchorRemainingAccounts
+  }, {
+    args
+  });
+  return {
+    instruction: initializeComponentIx,
+    transaction: new Transaction().add(initializeComponentIx)
   };
 }
 


### PR DESCRIPTION
## Problem

I noticed that the `apply` function used in world programs was missing from the SDK, so I added it.


## Solution

Added `Apply` function in `sdk/world/transactions.ts` file.


## Before & After Screenshots

**BEFORE**:
None

**AFTER**:
![image](https://github.com/user-attachments/assets/5a73e3c0-7f42-4082-bb47-a7e59033d587)
