### PR TITLE
test: test/script in relative paths

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,2 +1,7 @@
+set -e
+SCRIPT_DIR=$(dirname "$0")
+PROJECT_DIR="$SCRIPT_DIR/.."
+pushd "$PROJECT_DIR"
 cp tests/keys/* target/deploy/
 bolt test
+popd


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Tooling | No | None |

## Problem

`./scripts/test.sh` is only runnable from project root.


## Solution

Allow relative paths