### PR TITLE
feat: add missing apply function in sdk and add test for it

### DIFF
--- a/clients/bolt-sdk/src/generated/instructions/apply.ts
+++ b/clients/bolt-sdk/src/generated/instructions/apply.ts
@@ -50,6 +50,7 @@ export interface ApplyInstructionAccounts {
   boltComponent: web3.PublicKey;
   authority: web3.PublicKey;
   instructionSysvarAccount: web3.PublicKey;
+  world: web3.PublicKey;
   anchorRemainingAccounts?: web3.AccountMeta[];
 }
 
@@ -99,6 +100,11 @@ export function createApplyInstruction(
     },
     {
       pubkey: accounts.instructionSysvarAccount,
+      isWritable: false,
+      isSigner: false,
+    },
+    {
+      pubkey: accounts.world,
       isWritable: false,
       isSigner: false,
     },

--- a/clients/bolt-sdk/src/world/transactions.ts
+++ b/clients/bolt-sdk/src/world/transactions.ts
@@ -1,4 +1,5 @@
 import {
+  createApplyInstruction,
   createAddEntityInstruction,
   createInitializeComponentInstruction,
   createInitializeNewWorldInstruction,
@@ -300,6 +301,40 @@ export async function InitializeComponent({
     instruction: initializeComponentIx,
     transaction: new Transaction().add(initializeComponentIx),
     componentPda,
+  };
+}
+
+export async function Apply({
+  authority,
+  boltSystem,
+  boltComponent,
+  componentProgram,
+  anchorRemainingAccounts,
+  args
+}: {
+  authority: PublicKey;
+  boltSystem: PublicKey;
+  boltComponent: PublicKey;
+  componentProgram: PublicKey;
+  anchorRemainingAccounts?: web3.AccountMeta[];
+  args: Uint8Array;
+}): Promise<{
+  instruction: TransactionInstruction;
+  transaction: Transaction;
+}> {
+  const initializeComponentIx = createApplyInstruction({
+    authority,
+    boltSystem,
+    boltComponent,
+    componentProgram,
+    instructionSysvarAccount: SYSVAR_INSTRUCTIONS_PUBKEY,
+    anchorRemainingAccounts
+  }, {
+    args
+  });
+  return {
+    instruction: initializeComponentIx,
+    transaction: new Transaction().add(initializeComponentIx)
   };
 }
 

--- a/clients/bolt-sdk/src/world/transactions.ts
+++ b/clients/bolt-sdk/src/world/transactions.ts
@@ -48,14 +48,15 @@ export async function InitializeNewWorld({
   const registry = await Registry.fromAccountAddress(connection, registryPda);
   const worldId = new BN(registry.worlds);
   const worldPda = FindWorldPda({ worldId });
-  const initializeWorldIx = createInitializeNewWorldInstruction({
+  const instruction = createInitializeNewWorldInstruction({
     world: worldPda,
     registry: registryPda,
     payer,
   });
+  const transaction = new Transaction().add(instruction);
   return {
-    instruction: initializeWorldIx,
-    transaction: new Transaction().add(initializeWorldIx),
+    instruction,
+    transaction,
     worldPda,
     worldId,
   };
@@ -88,7 +89,7 @@ export async function AddAuthority({
   ) as unknown as Program<WorldProgram>;
   const worldInstance = await World.fromAccountAddress(connection, world);
   const worldId = new BN(worldInstance.id);
-  const addAuthorityIx = await program.methods
+  const instruction = await program.methods
     .addAuthority(worldId)
     .accounts({
       authority,
@@ -96,9 +97,10 @@ export async function AddAuthority({
       world,
     })
     .instruction();
+  const transaction = new Transaction().add(instruction);
   return {
-    instruction: addAuthorityIx,
-    transaction: new Transaction().add(addAuthorityIx),
+    instruction,
+    transaction,
   };
 }
 
@@ -129,7 +131,7 @@ export async function RemoveAuthority({
   ) as unknown as Program<WorldProgram>;
   const worldInstance = await World.fromAccountAddress(connection, world);
   const worldId = new BN(worldInstance.id);
-  const removeAuthorityIx = await program.methods
+  const instruction = await program.methods
     .removeAuthority(worldId)
     .accounts({
       authority,
@@ -137,9 +139,10 @@ export async function RemoveAuthority({
       world,
     })
     .instruction();
+  const transaction = new Transaction().add(instruction);
   return {
-    instruction: removeAuthorityIx,
-    transaction: new Transaction().add(removeAuthorityIx),
+    instruction,
+    transaction,
   };
 }
 
@@ -165,7 +168,7 @@ export async function ApproveSystem({
   const program = new Program(
     worldIdl as Idl,
   ) as unknown as Program<WorldProgram>;
-  const approveSystemIx = await program.methods
+  const instruction = await program.methods
     .approveSystem()
     .accounts({
       authority,
@@ -173,9 +176,10 @@ export async function ApproveSystem({
       world,
     })
     .instruction();
+  const transaction = new Transaction().add(instruction);
   return {
-    instruction: approveSystemIx,
-    transaction: new Transaction().add(approveSystemIx),
+    instruction,
+    transaction,
   };
 }
 
@@ -201,7 +205,7 @@ export async function RemoveSystem({
   const program = new Program(
     worldIdl as Idl,
   ) as unknown as Program<WorldProgram>;
-  const removeSystemIx = await program.methods
+  const instruction = await program.methods
     .removeSystem()
     .accounts({
       authority,
@@ -209,9 +213,10 @@ export async function RemoveSystem({
       world,
     })
     .instruction();
+  const transaction = new Transaction().add(instruction);
   return {
-    instruction: removeSystemIx,
-    transaction: new Transaction().add(removeSystemIx),
+    instruction,
+    transaction,
   };
 }
 
@@ -243,7 +248,7 @@ export async function AddEntity({
     seed !== undefined
       ? FindEntityPda({ worldId, seed })
       : FindEntityPda({ worldId, entityId: new BN(worldInstance.entities) });
-  const addEntityIx = createAddEntityInstruction(
+  const instruction = createAddEntityInstruction(
     {
       world,
       payer,
@@ -251,9 +256,10 @@ export async function AddEntity({
     },
     { extraSeed: seed ?? null },
   );
+  const transaction = new Transaction().add(instruction);
   return {
-    instruction: addEntityIx,
-    transaction: new Transaction().add(addEntityIx),
+    instruction,
+    transaction,
     entityPda,
   };
 }
@@ -288,7 +294,7 @@ export async function InitializeComponent({
   componentPda: PublicKey;
 }> {
   const componentPda = FindComponentPda({ componentId, entity, seed });
-  const initializeComponentIx = createInitializeComponentInstruction({
+  const instruction = createInitializeComponentInstruction({
     payer,
     entity,
     data: componentPda,
@@ -297,9 +303,10 @@ export async function InitializeComponent({
     instructionSysvarAccount: SYSVAR_INSTRUCTIONS_PUBKEY,
     anchorRemainingAccounts,
   });
+  const transaction = new Transaction().add(instruction);
   return {
-    instruction: initializeComponentIx,
-    transaction: new Transaction().add(initializeComponentIx),
+    instruction,
+    transaction,
     componentPda,
   };
 }
@@ -310,31 +317,38 @@ export async function Apply({
   boltComponent,
   componentProgram,
   anchorRemainingAccounts,
-  args
+  world,
+  args,
 }: {
   authority: PublicKey;
   boltSystem: PublicKey;
   boltComponent: PublicKey;
   componentProgram: PublicKey;
+  world: PublicKey;
   anchorRemainingAccounts?: web3.AccountMeta[];
   args: Uint8Array;
 }): Promise<{
   instruction: TransactionInstruction;
   transaction: Transaction;
 }> {
-  const initializeComponentIx = createApplyInstruction({
-    authority,
-    boltSystem,
-    boltComponent,
-    componentProgram,
-    instructionSysvarAccount: SYSVAR_INSTRUCTIONS_PUBKEY,
-    anchorRemainingAccounts
-  }, {
-    args
-  });
+  const instruction = createApplyInstruction(
+    {
+      authority,
+      boltSystem,
+      boltComponent,
+      componentProgram,
+      instructionSysvarAccount: SYSVAR_INSTRUCTIONS_PUBKEY,
+      anchorRemainingAccounts,
+      world,
+    },
+    {
+      args,
+    },
+  );
+  const transaction = new Transaction().add(instruction);
   return {
-    instruction: initializeComponentIx,
-    transaction: new Transaction().add(initializeComponentIx)
+    instruction,
+    transaction,
   };
 }
 
@@ -445,7 +459,7 @@ export async function ApplySystem({
   extraAccounts?: web3.AccountMeta[];
   args?: object;
 }): Promise<{ instruction: TransactionInstruction; transaction: Transaction }> {
-  const applySystemIx = await createApplySystemInstruction({
+  const instruction = await createApplySystemInstruction({
     authority,
     systemId,
     entities,
@@ -453,8 +467,9 @@ export async function ApplySystem({
     extraAccounts,
     args,
   });
+  const transaction = new Transaction().add(instruction);
   return {
-    instruction: applySystemIx,
-    transaction: new Transaction().add(applySystemIx),
+    instruction,
+    transaction,
   };
 }

--- a/tests/bolt.ts
+++ b/tests/bolt.ts
@@ -16,6 +16,7 @@ import {
   InitializeComponent,
   InitializeNewWorld,
   ApplySystem,
+  Apply,
   DelegateComponent,
   AddAuthority,
   RemoveAuthority,
@@ -24,6 +25,7 @@ import {
   type Program,
   anchor,
   web3,
+  SerializeArgs,
 } from "../clients/bolt-sdk";
 
 enum Direction {
@@ -314,6 +316,30 @@ describe("bolt", () => {
     expect(position.z.toNumber()).to.equal(0);
   });
 
+  it("Apply Simple Movement System (Up) on Entity 1 using Apply", async () => {
+    console.log("Apply", Apply);
+    const apply = await Apply({
+      authority: provider.wallet.publicKey,
+      boltSystem: exampleSystemSimpleMovement,
+      boltComponent: componentPositionEntity1Pda,
+      componentProgram: exampleComponentPosition.programId,
+      world: worldPda,
+      args: SerializeArgs({
+        direction: Direction.Up,
+      }),
+    });
+
+    await provider.sendAndConfirm(apply.transaction);
+
+    const position = await exampleComponentPosition.account.position.fetch(
+      componentPositionEntity1Pda,
+    );
+    logPosition("Movement System: Entity 1", position);
+    expect(position.x.toNumber()).to.equal(0);
+    expect(position.y.toNumber()).to.equal(1);
+    expect(position.z.toNumber()).to.equal(0);
+  });
+
   it("Apply Simple Movement System (Up) on Entity 1", async () => {
     const applySystem = await ApplySystem({
       authority: provider.wallet.publicKey,
@@ -341,7 +367,7 @@ describe("bolt", () => {
     );
     logPosition("Movement System: Entity 1", position);
     expect(position.x.toNumber()).to.equal(0);
-    expect(position.y.toNumber()).to.equal(1);
+    expect(position.y.toNumber()).to.equal(2);
     expect(position.z.toNumber()).to.equal(0);
   });
 
@@ -367,7 +393,7 @@ describe("bolt", () => {
     );
     logPosition("Movement System: Entity 1", position);
     expect(position.x.toNumber()).to.equal(1);
-    expect(position.y.toNumber()).to.equal(1);
+    expect(position.y.toNumber()).to.equal(2);
     expect(position.z.toNumber()).to.equal(0);
   });
 
@@ -390,7 +416,7 @@ describe("bolt", () => {
     );
     logPosition("Fly System: Entity 1", position);
     expect(position.x.toNumber()).to.equal(1);
-    expect(position.y.toNumber()).to.equal(1);
+    expect(position.y.toNumber()).to.equal(2);
     expect(position.z.toNumber()).to.equal(1);
   });
 
@@ -428,7 +454,7 @@ describe("bolt", () => {
     );
     logPosition("Apply System Velocity: Entity 1", position);
     expect(position.x.toNumber()).to.greaterThan(1);
-    expect(position.y.toNumber()).to.equal(1);
+    expect(position.y.toNumber()).to.equal(2);
     expect(position.z.toNumber()).to.equal(1);
   });
 
@@ -466,7 +492,7 @@ describe("bolt", () => {
     );
     logPosition("Apply System Velocity: Entity 1", position);
     expect(position.x.toNumber()).to.greaterThan(1);
-    expect(position.y.toNumber()).to.equal(1);
+    expect(position.y.toNumber()).to.equal(2);
     expect(position.z.toNumber()).to.equal(300);
   });
 


### PR DESCRIPTION
Original PR by @obstoody

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Feature | No | None |

## Problem

I noticed that the `apply` function used in world programs was missing from the SDK, so I added it.

## Solution

* Added `Apply` function in `sdk/world/transactions.ts` file.
* Fixed `createApplyInstruction` to take the world pda
* Added a test for it