### PR TITLE
test: adding bolt init test

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -95,4 +95,10 @@ jobs:
           yarn install && yarn build
           cd ../..
           bolt test
+      
+      - name: Initialize and test a new project
+        run: |
+          bolt init test-project
+          cd test-project
+          bolt test
 


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Hold | Test | No | #104 |

## Problem

* Projects created by `bolt init <project-name>` aren't tested.
* Projects created by `bolt init` are intermitently failing due to #104 

## Solution

* Add test to the CI
* Add `sleep 5` before the yarn test command