### PR TITLE
:sparkles: `bolt world` now prints world id

### DIFF
--- a/crates/bolt-cli/src/instructions.rs
+++ b/crates/bolt-cli/src/instructions.rs
@@ -84,8 +84,8 @@ pub fn create_world(cfg_override: &ConfigOverride) -> Result<()> {
         .send()?;
 
     println!(
-        "New world created {} with signature {}",
-        world_pda, signature
+        "New world created {} with world id {}. Transaction signature {}",
+        world_pda, world_id, signature
     );
 
     Ok(())


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | No | None |

## Problem

`bolt world` doesn't print the world ID that was just created

## Solution

Just print it

<!-- greptile_comment -->

## Greptile Summary

This PR enhances the output messaging of the `bolt world` command by adding the world ID to the creation confirmation message.

- Modified `crates/bolt-cli/src/instructions.rs` to include world ID in the output message when creating a new world
- Uses existing `world_id` variable from registry account, making it a safe, non-breaking change
- Improves UX by providing more complete information about newly created worlds



<sub>💡 (4/5) You can add custom instructions or style guidelines for the bot [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->