### PR TITLE
:bug: Fixing component naming convention to snake_case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,7 @@ name = "bolt-attribute-bolt-component"
 version = "0.2.1"
 dependencies = [
  "bolt-utils 0.2.1",
+ "ligen-ir",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1572,6 +1573,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,6 +1799,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1967,6 +1987,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2754,10 +2786,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
+name = "is-tree"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626ed8456ae78f787e675bdfec62f52a2bf0815cbfcb8deca13e16171853b75c"
+dependencies = [
+ "enum-as-inner",
+ "is-tree-macro",
+]
+
+[[package]]
+name = "is-tree-macro"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1c298b22f5336ec6f50850e139710265c4de4a0ae22e762485713a511b635b6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2924,6 +2986,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
 dependencies = [
  "libsecp256k1-core",
+]
+
+[[package]]
+name = "ligen-common"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffacf772830eecdb74ab98f14ebeee218d0a114ab1cde0f76e3512e036899391"
+dependencies = [
+ "derive_more",
+ "serde",
+ "serde_json",
+ "shrinkwraprs",
+]
+
+[[package]]
+name = "ligen-ir"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537fef82bb0e6ed638cbefa2a761f285a402a4ac6b88395aeeaa4be82b714b64"
+dependencies = [
+ "enum-as-inner",
+ "is-tree",
+ "ligen-common",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "strum",
 ]
 
 [[package]]
@@ -4113,6 +4203,9 @@ name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -4319,6 +4412,19 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shrinkwraprs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63e6744142336dfb606fe2b068afa2e1cca1ee6a5d8377277a92945d81fa331"
+dependencies = [
+ "bitflags 1.3.2",
+ "itertools 0.8.2",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -5610,6 +5716,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.79",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ solana-client = { version = "=1.16" }
 solana-security-txt = "1.1.1"
 tuple-conv = "1.0.1"
 syn = { version = "1.0.60", features = ["full"] }
+ligen-ir = { version = "=0.1.18" }
 quote = "1.0"
 proc-macro2 = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/bolt-lang/attribute/component/Cargo.toml
+++ b/crates/bolt-lang/attribute/component/Cargo.toml
@@ -13,6 +13,7 @@ proc-macro = true
 
 [dependencies]
 syn = { workspace = true }
+ligen-ir = { workspace = true }
 bolt-utils = { workspace = true }
 quote = { workspace = true }
 proc-macro2 = { workspace = true }

--- a/crates/bolt-lang/attribute/component/src/lib.rs
+++ b/crates/bolt-lang/attribute/component/src/lib.rs
@@ -53,7 +53,8 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
     add_bolt_metadata(&mut input);
 
     let name = &input.ident;
-    let component_name = syn::Ident::new(&name.to_string().to_lowercase(), input.ident.span());
+    let component_name = ligen_ir::Identifier::new(name.to_string()).to_snake_case();
+    let component_name = syn::Ident::new(&component_name.to_string(), input.ident.span());
 
     let bolt_program = if delegate_set {
         quote! {


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug | Yes | #131  |

## Problem

Described in #131.
The component program name was just changed to lowercase instead of actually converting the naming convention.

## Solution

Fixing the naming convention to `snake_case`

## Breaking change

Idk what people have been doing with this issue, but it will affect them if they had any workaround.

**New dependencies**:

- `ligen-ir 0.1.18` : It has lots of helpers for attributes parsing and general programming conventions.

<!-- greptile_comment -->

## Greptile Summary

This PR fixes component naming convention inconsistencies by implementing proper snake_case conversion using the ligen-ir library.

- Added `ligen-ir` dependency in `/crates/bolt-lang/attribute/component/Cargo.toml` for standardized naming conventions
- Modified component name generation in `/crates/bolt-lang/attribute/component/src/lib.rs` to use `ligen_ir::Identifier::new().to_snake_case()`
- Fixes issue #131 where `bolt component an-example` and `bolt system an-example` produced inconsistent file names
- Breaking change: Components will now consistently use snake_case instead of lowercase naming



<!-- /greptile_comment -->