### PR TITLE
:sparkles: TypeScript ApplySystem now takes any JSON serializable as input

### DIFF
--- a/clients/bolt-sdk/src/world/transactions.ts
+++ b/clients/bolt-sdk/src/world/transactions.ts
@@ -383,7 +383,7 @@ interface ApplySystemInstruction {
   world: PublicKey;
   session?: Session;
   extraAccounts?: web3.AccountMeta[];
-  args?: object;
+  args?: any;
 }
 async function createApplySystemInstruction({
   authority,
@@ -491,7 +491,7 @@ export async function ApplySystem({
   entities: ApplySystemEntity[];
   world: PublicKey;
   extraAccounts?: web3.AccountMeta[];
-  args?: object;
+  args?: any;
   session?: Session;
 }): Promise<{ instruction: TransactionInstruction; transaction: Transaction }> {
   const instruction = await createApplySystemInstruction({


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | No | None |

## Problem

ApplySystem input data only accepts JSON objects when it should accept any kind of JSON type (Object, Array, String, ...)

## Solution

Change TS type from `object` to `any`

<!-- greptile_comment -->

## Greptile Summary

This PR modifies the ApplySystem function in the Bolt SDK to accept any JSON-serializable type as input, rather than being restricted to only objects.

- Changed `args` parameter type from `object` to `any` in `/clients/bolt-sdk/src/world/transactions.ts` to support arrays, strings and other JSON types
- Maintains backward compatibility since objects are still valid JSON-serializable inputs
- Affects type safety by removing object-type constraints, but increases flexibility for different data structures
- Aligns with the underlying program which can handle any serialized JSON data



<!-- /greptile_comment -->