### PR TITLE
:green_heart: Fixing bolt-sdk publish CI

### DIFF
--- a/.github/workflows/publish-bolt-sdk.yml
+++ b/.github/workflows/publish-bolt-sdk.yml
@@ -85,7 +85,7 @@ jobs:
         run: yarn lint
 
   test:
-    needs: [clippy-lint, yarn-lint]
+    needs: [yarn-lint]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Hotfix | No | None |

## Problem

publish-bolt-sdk is broken because it depends on a removed step

## Solution

Remove the dependency

<!-- greptile_comment -->

## Greptile Summary

This PR addresses a critical CI fix for the bolt-sdk publishing workflow. Here's a concise summary of the changes and issues:

- Removes broken dependency on 'clippy-lint' step from test job to fix the workflow
- Several workflow inconsistencies and inefficiencies identified in `.github/workflows/publish-bolt-sdk.yml`:
  - Inconsistent cache action versions (v3/v4) need standardization
  - Commented cache configuration needs proper implementation
  - Redundant node_modules installation and Solana CLI caching steps should be consolidated
  - Missing explicit error handling for npm publish operation
  - Duplicate setup steps between jobs could be optimized

The fix is necessary for CI stability, but the workflow could benefit from additional optimization to improve reliability and efficiency.



<!-- /greptile_comment -->