### PR TITLE
✨ Separating apply and apply_with_session

### DIFF
--- a/clients/bolt-sdk/src/generated/idl/world.json
+++ b/clients/bolt-sdk/src/generated/idl/world.json
@@ -2,7 +2,7 @@
   "address": "WorLD15A7CrDwLcLy4fRqtaTb9fbd8o8iqiEMUDse2n",
   "metadata": {
     "name": "world",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "spec": "0.1.0",
     "description": "Bolt World program",
     "repository": "https://github.com/magicblock-labs/bolt"

--- a/clients/bolt-sdk/src/generated/idl/world.json
+++ b/clients/bolt-sdk/src/generated/idl/world.json
@@ -111,10 +111,44 @@
         },
         {
           "name": "world"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "apply_with_session",
+      "discriminator": [
+        213,
+        69,
+        29,
+        230,
+        142,
+        107,
+        134,
+        103
+      ],
+      "accounts": [
+        {
+          "name": "bolt_system"
         },
         {
-          "name": "session_token",
-          "optional": true
+          "name": "authority",
+          "signer": true
+        },
+        {
+          "name": "instruction_sysvar_account",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        },
+        {
+          "name": "world"
+        },
+        {
+          "name": "session_token"
         }
       ],
       "args": [

--- a/clients/bolt-sdk/src/generated/types/world.ts
+++ b/clients/bolt-sdk/src/generated/types/world.ts
@@ -8,7 +8,7 @@ export type World = {
   address: "WorLD15A7CrDwLcLy4fRqtaTb9fbd8o8iqiEMUDse2n";
   metadata: {
     name: "world";
-    version: "0.2.0";
+    version: "0.2.1";
     spec: "0.1.0";
     description: "Bolt World program";
     repository: "https://github.com/magicblock-labs/bolt";

--- a/clients/bolt-sdk/src/generated/types/world.ts
+++ b/clients/bolt-sdk/src/generated/types/world.ts
@@ -91,9 +91,34 @@ export type World = {
         {
           name: "world";
         },
+      ];
+      args: [
+        {
+          name: "args";
+          type: "bytes";
+        },
+      ];
+    },
+    {
+      name: "applyWithSession";
+      discriminator: [213, 69, 29, 230, 142, 107, 134, 103];
+      accounts: [
+        {
+          name: "boltSystem";
+        },
+        {
+          name: "authority";
+          signer: true;
+        },
+        {
+          name: "instructionSysvarAccount";
+          address: "Sysvar1nstructions1111111111111111111111111";
+        },
+        {
+          name: "world";
+        },
         {
           name: "sessionToken";
-          optional: true;
         },
       ];
       args: [

--- a/clients/bolt-sdk/src/world/transactions.ts
+++ b/clients/bolt-sdk/src/world/transactions.ts
@@ -405,15 +405,6 @@ async function createApplySystemInstruction({
     throw new Error("No components provided");
   }
 
-  let sessionToken = session ? session.token : null;
-
-  const applyAccounts = {
-    authority: authority ?? PROGRAM_ID,
-    boltSystem: systemId,
-    sessionToken,
-    world,
-  };
-
   let remainingAccounts: web3.AccountMeta[] = [];
   let components: { id: PublicKey; pda: PublicKey }[] = [];
   for (const entity of entities) {
@@ -452,11 +443,28 @@ async function createApplySystemInstruction({
       remainingAccounts.push(account);
     }
   }
-  return program.methods
-    .apply(SerializeArgs(args))
-    .accounts(applyAccounts)
-    .remainingAccounts(remainingAccounts)
-    .instruction();
+
+  if (session)
+    return program.methods
+      .applyWithSession(SerializeArgs(args))
+      .accounts({
+        authority: authority ?? PROGRAM_ID,
+        boltSystem: systemId,
+        sessionToken: session.token,
+        world,
+      })
+      .remainingAccounts(remainingAccounts)
+      .instruction();
+  else
+    return program.methods
+      .apply(SerializeArgs(args))
+      .accounts({
+        authority: authority ?? PROGRAM_ID,
+        boltSystem: systemId,
+        world,
+      })
+      .remainingAccounts(remainingAccounts)
+      .instruction();
 }
 
 interface ApplySystemEntity {

--- a/crates/programs/world/src/lib.rs
+++ b/crates/programs/world/src/lib.rs
@@ -269,7 +269,14 @@ pub mod world {
         ctx: Context<'_, '_, '_, 'info, Apply<'info>>,
         args: Vec<u8>,
     ) -> Result<()> {
-        let (pairs, results) = apply_impl(&ctx.accounts.authority, &ctx.accounts.world, &ctx.accounts.bolt_system, ctx.accounts.build(), args, ctx.remaining_accounts.to_vec())?;
+        let (pairs, results) = apply_impl(
+            &ctx.accounts.authority,
+            &ctx.accounts.world,
+            &ctx.accounts.bolt_system,
+            ctx.accounts.build(),
+            args,
+            ctx.remaining_accounts.to_vec(),
+        )?;
         for ((program, component), result) in pairs.into_iter().zip(results.into_iter()) {
             bolt_component::cpi::update(
                 build_update_context(
@@ -315,7 +322,14 @@ pub mod world {
         ctx: Context<'_, '_, '_, 'info, ApplyWithSession<'info>>,
         args: Vec<u8>,
     ) -> Result<()> {
-        let (pairs, results) = apply_impl(&ctx.accounts.authority, &ctx.accounts.world, &ctx.accounts.bolt_system, ctx.accounts.build(), args, ctx.remaining_accounts.to_vec())?;
+        let (pairs, results) = apply_impl(
+            &ctx.accounts.authority,
+            &ctx.accounts.world,
+            &ctx.accounts.bolt_system,
+            ctx.accounts.build(),
+            args,
+            ctx.remaining_accounts.to_vec(),
+        )?;
         for ((program, component), result) in pairs.into_iter().zip(results.into_iter()) {
             bolt_component::cpi::update_with_session(
                 build_update_context_with_session(
@@ -361,10 +375,16 @@ pub mod world {
     }
 }
 
-fn apply_impl<'info>(authority: &Signer<'info>, world: &Account<'info, World>, bolt_system: &UncheckedAccount<'info>, cpi_context: CpiContext<'_, '_, '_, 'info, bolt_system::cpi::accounts::BoltExecute<'info>>, args: Vec<u8>, mut remaining_accounts: Vec<AccountInfo<'info>>) -> Result<(Vec<(AccountInfo<'info>, AccountInfo<'info>)>, Vec<Vec<u8>>)> {
-    if !authority.is_signer
-    && authority.key != &ID
-    {
+#[allow(clippy::type_complexity)]
+fn apply_impl<'info>(
+    authority: &Signer<'info>,
+    world: &Account<'info, World>,
+    bolt_system: &UncheckedAccount<'info>,
+    cpi_context: CpiContext<'_, '_, '_, 'info, bolt_system::cpi::accounts::BoltExecute<'info>>,
+    args: Vec<u8>,
+    mut remaining_accounts: Vec<AccountInfo<'info>>,
+) -> Result<(Vec<(AccountInfo<'info>, AccountInfo<'info>)>, Vec<Vec<u8>>)> {
+    if !authority.is_signer && authority.key != &ID {
         return Err(WorldError::InvalidAuthority.into());
     }
     if !world.permissionless
@@ -395,8 +415,7 @@ fn apply_impl<'info>(authority: &Signer<'info>, world: &Account<'info, World>, b
     let remaining_accounts = components_accounts;
 
     let results = bolt_system::cpi::bolt_execute(
-        cpi_context
-            .with_remaining_accounts(remaining_accounts),
+        cpi_context.with_remaining_accounts(remaining_accounts),
         args,
     )?
     .get();
@@ -650,7 +669,7 @@ pub fn build_update_context<'info>(
     bolt_component::cpi::accounts::Update {
         bolt_component,
         authority,
-        instruction_sysvar_account
+        instruction_sysvar_account,
     }
     .build_cpi_context(cpi_program)
 }
@@ -662,7 +681,8 @@ pub fn build_update_context_with_session<'info>(
     authority: Signer<'info>,
     instruction_sysvar_account: UncheckedAccount<'info>,
     session_token: UncheckedAccount<'info>,
-) -> CpiContext<'info, 'info, 'info, 'info, bolt_component::cpi::accounts::UpdateWithSession<'info>> {
+) -> CpiContext<'info, 'info, 'info, 'info, bolt_component::cpi::accounts::UpdateWithSession<'info>>
+{
     let authority = authority.to_account_info();
     let instruction_sysvar_account = instruction_sysvar_account.to_account_info();
     let cpi_program = component_program;

--- a/crates/programs/world/src/lib.rs
+++ b/crates/programs/world/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::manual_unwrap_or_default)]
 use anchor_lang::prelude::*;
 use bolt_component::CpiContextBuilder;
+use error::WorldError;
 use std::collections::BTreeSet;
 
 #[cfg(not(feature = "no-entrypoint"))]
@@ -268,55 +269,7 @@ pub mod world {
         ctx: Context<'_, '_, '_, 'info, Apply<'info>>,
         args: Vec<u8>,
     ) -> Result<()> {
-        if !ctx.accounts.authority.is_signer
-            && ctx.accounts.authority.key != &ID
-            && ctx.accounts.session_token.is_none()
-        {
-            return Err(WorldError::InvalidAuthority.into());
-        }
-        if !ctx.accounts.world.permissionless
-            && !ctx
-                .accounts
-                .world
-                .systems()
-                .approved_systems
-                .contains(&ctx.accounts.bolt_system.key())
-        {
-            return Err(WorldError::SystemNotApproved.into());
-        }
-
-        let mut remaining_accounts: Vec<AccountInfo<'info>> = ctx.remaining_accounts.to_vec();
-
-        let mut pairs = Vec::new();
-        while remaining_accounts.len() >= 2 {
-            let program = remaining_accounts.remove(0);
-            if program.key() == ID {
-                break;
-            }
-            let component = remaining_accounts.remove(0);
-            pairs.push((program, component));
-        }
-
-        let mut components_accounts = pairs
-            .iter()
-            .map(|(_, component)| component)
-            .cloned()
-            .collect::<Vec<_>>();
-        components_accounts.append(&mut remaining_accounts);
-        let remaining_accounts = components_accounts;
-
-        let results = bolt_system::cpi::bolt_execute(
-            ctx.accounts
-                .build()
-                .with_remaining_accounts(remaining_accounts),
-            args,
-        )?
-        .get();
-
-        if results.len() != pairs.len() {
-            return Err(WorldError::InvalidSystemOutput.into());
-        }
-
+        let (pairs, results) = apply_impl(&ctx.accounts.authority, &ctx.accounts.world, &ctx.accounts.bolt_system, ctx.accounts.build(), args, ctx.remaining_accounts.to_vec())?;
         for ((program, component), result) in pairs.into_iter().zip(results.into_iter()) {
             bolt_component::cpi::update(
                 build_update_context(
@@ -324,7 +277,6 @@ pub mod world {
                     component,
                     ctx.accounts.authority.clone(),
                     ctx.accounts.instruction_sysvar_account.clone(),
-                    ctx.accounts.session_token.clone(),
                 ),
                 result,
             )?;
@@ -345,8 +297,6 @@ pub mod world {
         pub instruction_sysvar_account: UncheckedAccount<'info>,
         #[account()]
         pub world: Account<'info, World>,
-        #[account()]
-        pub session_token: Option<UncheckedAccount<'info>>,
     }
 
     impl<'info> Apply<'info> {
@@ -360,6 +310,101 @@ pub mod world {
             CpiContext::new(cpi_program, cpi_accounts)
         }
     }
+
+    pub fn apply_with_session<'info>(
+        ctx: Context<'_, '_, '_, 'info, ApplyWithSession<'info>>,
+        args: Vec<u8>,
+    ) -> Result<()> {
+        let (pairs, results) = apply_impl(&ctx.accounts.authority, &ctx.accounts.world, &ctx.accounts.bolt_system, ctx.accounts.build(), args, ctx.remaining_accounts.to_vec())?;
+        for ((program, component), result) in pairs.into_iter().zip(results.into_iter()) {
+            bolt_component::cpi::update_with_session(
+                build_update_context_with_session(
+                    program,
+                    component,
+                    ctx.accounts.authority.clone(),
+                    ctx.accounts.instruction_sysvar_account.clone(),
+                    ctx.accounts.session_token.clone(),
+                ),
+                result,
+            )?;
+        }
+        Ok(())
+    }
+
+    #[derive(Accounts)]
+    pub struct ApplyWithSession<'info> {
+        /// CHECK: bolt system program check
+        #[account()]
+        pub bolt_system: UncheckedAccount<'info>,
+        /// CHECK: authority check
+        #[account()]
+        pub authority: Signer<'info>,
+        /// CHECK: instruction sysvar check
+        #[account(address = anchor_lang::solana_program::sysvar::instructions::id())]
+        pub instruction_sysvar_account: UncheckedAccount<'info>,
+        #[account()]
+        pub world: Account<'info, World>,
+        #[account()]
+        pub session_token: UncheckedAccount<'info>,
+    }
+
+    impl<'info> ApplyWithSession<'info> {
+        pub fn build(
+            &self,
+        ) -> CpiContext<'_, '_, '_, 'info, bolt_system::cpi::accounts::BoltExecute<'info>> {
+            let cpi_program = self.bolt_system.to_account_info();
+            let cpi_accounts = bolt_system::cpi::accounts::BoltExecute {
+                authority: self.authority.to_account_info(),
+            };
+            CpiContext::new(cpi_program, cpi_accounts)
+        }
+    }
+}
+
+fn apply_impl<'info>(authority: &Signer<'info>, world: &Account<'info, World>, bolt_system: &UncheckedAccount<'info>, cpi_context: CpiContext<'_, '_, '_, 'info, bolt_system::cpi::accounts::BoltExecute<'info>>, args: Vec<u8>, mut remaining_accounts: Vec<AccountInfo<'info>>) -> Result<(Vec<(AccountInfo<'info>, AccountInfo<'info>)>, Vec<Vec<u8>>)> {
+    if !authority.is_signer
+    && authority.key != &ID
+    {
+        return Err(WorldError::InvalidAuthority.into());
+    }
+    if !world.permissionless
+        && !world
+            .systems()
+            .approved_systems
+            .contains(&bolt_system.key())
+    {
+        return Err(WorldError::SystemNotApproved.into());
+    }
+
+    let mut pairs = Vec::new();
+    while remaining_accounts.len() >= 2 {
+        let program = remaining_accounts.remove(0);
+        if program.key() == ID {
+            break;
+        }
+        let component = remaining_accounts.remove(0);
+        pairs.push((program, component));
+    }
+
+    let mut components_accounts = pairs
+        .iter()
+        .map(|(_, component)| component)
+        .cloned()
+        .collect::<Vec<_>>();
+    components_accounts.append(&mut remaining_accounts);
+    let remaining_accounts = components_accounts;
+
+    let results = bolt_system::cpi::bolt_execute(
+        cpi_context
+            .with_remaining_accounts(remaining_accounts),
+        args,
+    )?
+    .get();
+
+    if results.len() != pairs.len() {
+        return Err(WorldError::InvalidSystemOutput.into());
+    }
+    Ok((pairs, results))
 }
 
 #[derive(Accounts)]
@@ -598,13 +643,31 @@ pub fn build_update_context<'info>(
     bolt_component: AccountInfo<'info>,
     authority: Signer<'info>,
     instruction_sysvar_account: UncheckedAccount<'info>,
-    session_token: Option<UncheckedAccount<'info>>,
 ) -> CpiContext<'info, 'info, 'info, 'info, bolt_component::cpi::accounts::Update<'info>> {
     let authority = authority.to_account_info();
     let instruction_sysvar_account = instruction_sysvar_account.to_account_info();
     let cpi_program = component_program;
-    let session_token = session_token.map(|x| x.to_account_info());
     bolt_component::cpi::accounts::Update {
+        bolt_component,
+        authority,
+        instruction_sysvar_account
+    }
+    .build_cpi_context(cpi_program)
+}
+
+/// Builds the context for updating a component.
+pub fn build_update_context_with_session<'info>(
+    component_program: AccountInfo<'info>,
+    bolt_component: AccountInfo<'info>,
+    authority: Signer<'info>,
+    instruction_sysvar_account: UncheckedAccount<'info>,
+    session_token: UncheckedAccount<'info>,
+) -> CpiContext<'info, 'info, 'info, 'info, bolt_component::cpi::accounts::UpdateWithSession<'info>> {
+    let authority = authority.to_account_info();
+    let instruction_sysvar_account = instruction_sysvar_account.to_account_info();
+    let cpi_program = component_program;
+    let session_token = session_token.to_account_info();
+    bolt_component::cpi::accounts::UpdateWithSession {
         bolt_component,
         authority,
         instruction_sysvar_account,

--- a/tests/low-level/session.ts
+++ b/tests/low-level/session.ts
@@ -84,7 +84,7 @@ export function session(framework) {
         );
 
       const instruction = await framework.worldProgram.methods
-        .apply(SerializeArgs())
+        .applyWithSession(SerializeArgs())
         .accounts({
           authority: sessionSigner.publicKey,
           boltSystem: framework.systemFly.programId,
@@ -170,7 +170,7 @@ export function session(framework) {
         );
 
       const instruction = await framework.worldProgram.methods
-        .apply(SerializeArgs())
+        .applyWithSession(SerializeArgs())
         .accounts({
           authority: sessionSigner.publicKey,
           boltSystem: framework.systemFly.programId,


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | Yes | #140  |

## Problem

We want to separate apply and apply_with_session. This will be part of our effort to keep API compatibility.

<!-- greptile_comment -->

## Greptile Summary

This PR separates the `apply` and `apply_with_session` functions in the Bolt SDK to maintain API compatibility and provide clearer distinction between session-based and non-session operations.

- Added new `update_with_session` instruction in `/crates/programs/bolt-component/src/lib.rs` with dedicated `UpdateWithSession` struct for session token handling
- Split `apply` instruction into two distinct instructions in `/clients/bolt-sdk/src/generated/idl/world.json` with separate discriminators and account structures
- Extracted common logic into `apply_impl` function in `/crates/programs/world/src/lib.rs` to avoid code duplication
- Modified transaction handling in `/clients/bolt-sdk/src/world/transactions.ts` to route to appropriate method based on session presence
- Added comprehensive session-based tests in `/tests/low-level/session.ts` to verify functionality



<!-- /greptile_comment -->