### PR TITLE
✅ Install ephemeral validator on test automation

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -47,6 +47,10 @@ jobs:
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
           solana --version
 
+      - name: Install Ephemeral Validator
+        run: |
+          npm install --global @magicblock-labs/ephemeral-validator
+
   test:
     needs: setup
     runs-on: ubuntu-latest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,11 +46,6 @@ jobs:
           export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
           solana --version
-
-      - name: Install Ephemeral Validator
-        run: |
-          npm install --global @magicblock-labs/ephemeral-validator
-
   test:
     needs: setup
     runs-on: ubuntu-latest
@@ -71,6 +66,10 @@ jobs:
           export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
           solana --version
+
+      - name: Install Ephemeral Validator
+        run: |
+          npm install --global @magicblock-labs/ephemeral-validator
 
       - name: Create keypair
         run: |

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
         "lint": "node_modules/.bin/prettier */*.js \"*/**/*{.js,.ts}\" --check"
     },
     "devDependencies": {
-        "@magicblock-labs/ephemeral-validator": "^0.1.0",
         "@metaplex-foundation/beet": "^0.7.1",
         "@metaplex-foundation/beet-solana": "^0.4.0",
         "@types/bn.js": "^5.1.0",


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Tooling | No | None |

<!-- greptile_comment -->

## Greptile Summary

Modified the ephemeral validator installation approach by moving it from project dependencies to a global installation in the CI/CD workflow.

- Removed `@magicblock-labs/ephemeral-validator` from `package.json` devDependencies
- Added global installation step `npm install --global @magicblock-labs/ephemeral-validator` in `.github/workflows/run-tests.yml`
- Installation now occurs before keypair creation in the test workflow



<!-- /greptile_comment -->