### PR TITLE
:bookmark: Bolt v0.2.3

### DIFF
--- a/.github/workflows/publish-bolt-crates.yml
+++ b/.github/workflows/publish-bolt-crates.yml
@@ -51,6 +51,11 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly
+
       - name: Cache rust
         uses: Swatinem/rust-cache@v2
 
@@ -170,23 +175,22 @@ jobs:
             NO_VERIFY_FLAG="--no-verify"
           fi      
 
-          cargo publish $DRY_RUN_FLAG --manifest-path=crates/bolt-lang/utils/Cargo.toml --token $CRATES_TOKEN $NO_VERIFY_FLAG
-          cargo publish $DRY_RUN_FLAG --manifest-path=crates/bolt-lang/attribute/component/Cargo.toml --token $CRATES_TOKEN $NO_VERIFY_FLAG
-          cargo publish $DRY_RUN_FLAG --manifest-path=crates/bolt-lang/attribute/component-deserialize/Cargo.toml --token $CRATES_TOKEN $NO_VERIFY_FLAG
-          cargo publish $DRY_RUN_FLAG --manifest-path=crates/bolt-lang/attribute/component-id/Cargo.toml --token $CRATES_TOKEN $NO_VERIFY_FLAG
-          cargo publish $DRY_RUN_FLAG --manifest-path=crates/bolt-lang/attribute/system/Cargo.toml --token $CRATES_TOKEN $NO_VERIFY_FLAG
-          cargo publish $DRY_RUN_FLAG --manifest-path=crates/bolt-lang/attribute/system-input/Cargo.toml --token $CRATES_TOKEN $NO_VERIFY_FLAG
-          cargo publish $DRY_RUN_FLAG --manifest-path=crates/bolt-lang/attribute/extra-accounts/Cargo.toml --token $CRATES_TOKEN $NO_VERIFY_FLAG
-          cargo publish $DRY_RUN_FLAG --manifest-path=crates/bolt-lang/attribute/arguments/Cargo.toml --token $CRATES_TOKEN $NO_VERIFY_FLAG
-          cargo publish $DRY_RUN_FLAG --manifest-path=crates/bolt-lang/attribute/bolt-program/Cargo.toml --token $CRATES_TOKEN $NO_VERIFY_FLAG
-          cargo publish $DRY_RUN_FLAG --manifest-path=crates/bolt-lang/attribute/delegate/Cargo.toml --token $CRATES_TOKEN $NO_VERIFY_FLAG
-          cargo publish $DRY_RUN_FLAG --manifest-path=crates/programs/bolt-system/Cargo.toml --token $CRATES_TOKEN $NO_VERIFY_FLAG
-          cargo publish $DRY_RUN_FLAG --manifest-path=crates/programs/bolt-component/Cargo.toml --token $CRATES_TOKEN $NO_VERIFY_FLAG
-          cargo publish $DRY_RUN_FLAG --manifest-path=crates/programs/world/Cargo.toml --token $CRATES_TOKEN $NO_VERIFY_FLAG
-          cargo publish $DRY_RUN_FLAG --manifest-path=crates/bolt-lang/Cargo.toml --token $CRATES_TOKEN $NO_VERIFY_FLAG
-          if [ "${DRY_RUN}" != "true" ]; then
-            cargo publish --manifest-path=crates/bolt-cli/Cargo.toml --token $CRATES_TOKEN
-          fi
+          cargo +nightly publish -Zpackage-workspace $DRY_RUN_FLAG $NO_VERIFY_FLAG --token $CRATES_TOKEN \
+            -p world \
+            -p bolt-cli \
+            -p bolt-lang \
+            -p bolt-utils \
+            -p bolt-system \
+            -p bolt-component \
+            -p bolt-attribute-bolt-arguments \
+            -p bolt-attribute-bolt-component \
+            -p bolt-attribute-bolt-component-deserialize \
+            -p bolt-attribute-bolt-component-id \
+            -p bolt-attribute-bolt-delegate \
+            -p bolt-attribute-bolt-extra-accounts \
+            -p bolt-attribute-bolt-program \
+            -p bolt-attribute-bolt-system \
+            -p bolt-attribute-bolt-system-input
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
           DRY_RUN: ${{ env.DRY_RUN }}

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -183,7 +183,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   publish-wrapper-npm-package:
     name: Publish wrapper NPM packages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: publish-npm-binaries
     steps:
       - name: Checkout

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,7 +785,7 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bolt-attribute-bolt-arguments"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "bolt-attribute-bolt-component"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bolt-utils",
  "ligen-ir",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "bolt-attribute-bolt-component-deserialize"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bolt-utils",
  "proc-macro2",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "bolt-attribute-bolt-component-id"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "bolt-attribute-bolt-delegate"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "bolt-attribute-bolt-extra-accounts"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "bolt-attribute-bolt-program"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "bolt-attribute-bolt-system"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "bolt-attribute-bolt-system-input"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "bolt-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anchor-cli",
  "anchor-client",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "bolt-component"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anchor-lang",
  "bolt-system",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "bolt-lang"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "ahash",
  "anchor-lang",
@@ -922,21 +922,21 @@ dependencies = [
 
 [[package]]
 name = "bolt-system"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anchor-lang",
 ]
 
 [[package]]
 name = "bolt-types"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bolt-lang",
 ]
 
 [[package]]
 name = "bolt-utils"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3261,7 +3261,7 @@ dependencies = [
 
 [[package]]
 name = "position"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bolt-lang",
 ]
@@ -5283,7 +5283,7 @@ dependencies = [
 
 [[package]]
 name = "system-apply-velocity"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bolt-lang",
  "mpl-token-metadata",
@@ -5314,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "system-fly"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bolt-lang",
  "position",
@@ -5322,7 +5322,7 @@ dependencies = [
 
 [[package]]
 name = "system-simple-movement"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bolt-lang",
  "bolt-types",
@@ -5859,7 +5859,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "velocity"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bolt-lang",
 ]
@@ -6298,7 +6298,7 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "world"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anchor-lang",
  "bolt-component",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Magicblock Labs <dev@magicblock.gg>"]
 repository = "https://github.com/magicblock-labs/bolt"
 homepage = "https://www.magicblock.gg/"
@@ -19,21 +19,21 @@ license = "MIT"
 edition = "2021"
 
 [workspace.dependencies]
-bolt-types = { path = "crates/types", version = "=0.2.2" }
-bolt-lang = { path = "crates/bolt-lang", version = "=0.2.2" }
-bolt-attribute-bolt-program = { path = "crates/bolt-lang/attribute/bolt-program", version = "=0.2.2" }
-bolt-attribute-bolt-delegate = { path = "crates/bolt-lang/attribute/delegate", version = "=0.2.2" }
-bolt-attribute-bolt-component = { path = "crates/bolt-lang/attribute/component", version = "=0.2.2" }
-bolt-attribute-bolt-system = { path = "crates/bolt-lang/attribute/system", version = "=0.2.2"}
-bolt-attribute-bolt-system-input = { path = "crates/bolt-lang/attribute/system-input", version = "=0.2.2" }
-bolt-attribute-bolt-extra-accounts = { path = "crates/bolt-lang/attribute/extra-accounts", version = "=0.2.2" }
-bolt-attribute-bolt-arguments = { path = "crates/bolt-lang/attribute/arguments", version = "=0.2.2" }
-bolt-attribute-bolt-component-deserialize = { path = "crates/bolt-lang/attribute/component-deserialize", version = "=0.2.2" }
-bolt-attribute-bolt-component-id = { path = "crates/bolt-lang/attribute/component-id", version = "=0.2.2" }
-bolt-utils = { path = "crates/bolt-lang/utils", version = "=0.2.2" }
-world = { path = "crates/programs/world", features = ["cpi"], version = "=0.2.2"}
-bolt-system = { path = "crates/programs/bolt-system", features = ["cpi"], version = "=0.2.2"}
-bolt-component = { path = "crates/programs/bolt-component", features = ["cpi"], version = "=0.2.2"}
+bolt-types = { path = "crates/types", version = "=0.2.3" }
+bolt-lang = { path = "crates/bolt-lang", version = "=0.2.3" }
+bolt-attribute-bolt-program = { path = "crates/bolt-lang/attribute/bolt-program", version = "=0.2.3" }
+bolt-attribute-bolt-delegate = { path = "crates/bolt-lang/attribute/delegate", version = "=0.2.3" }
+bolt-attribute-bolt-component = { path = "crates/bolt-lang/attribute/component", version = "=0.2.3" }
+bolt-attribute-bolt-system = { path = "crates/bolt-lang/attribute/system", version = "=0.2.3"}
+bolt-attribute-bolt-system-input = { path = "crates/bolt-lang/attribute/system-input", version = "=0.2.3" }
+bolt-attribute-bolt-extra-accounts = { path = "crates/bolt-lang/attribute/extra-accounts", version = "=0.2.3" }
+bolt-attribute-bolt-arguments = { path = "crates/bolt-lang/attribute/arguments", version = "=0.2.3" }
+bolt-attribute-bolt-component-deserialize = { path = "crates/bolt-lang/attribute/component-deserialize", version = "=0.2.3" }
+bolt-attribute-bolt-component-id = { path = "crates/bolt-lang/attribute/component-id", version = "=0.2.3" }
+bolt-utils = { path = "crates/bolt-lang/utils", version = "=0.2.3" }
+world = { path = "crates/programs/world", features = ["cpi"], version = "=0.2.3"}
+bolt-system = { path = "crates/programs/bolt-system", features = ["cpi"], version = "=0.2.3"}
+bolt-component = { path = "crates/programs/bolt-component", features = ["cpi"], version = "=0.2.3"}
 
 ## External crates
 session-keys       = { version = ">=2.0.7", features = ["no-entrypoint"] }

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicblock-labs/bolt-sdk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Bolt typescript SDK",
   "author": "dev@magicblock.gg",
   "license": "MIT",

--- a/crates/bolt-cli/npm-package/package.json
+++ b/crates/bolt-cli/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicblock-labs/bolt-cli",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Bolt CLI tool",
   "homepage": "https://github.com/magicblock-labs/bolt#readme",
   "bugs": {
@@ -27,13 +27,13 @@
     "prettier": "^3.3.3"
   },
   "optionalDependencies": {
-    "@magicblock-labs/bolt-cli-darwin-x64": "0.2.2",
-    "@magicblock-labs/bolt-cli-darwin-arm64": "0.2.2",
-    "@magicblock-labs/bolt-cli-linux-x86": "0.2.2",
-    "@magicblock-labs/bolt-cli-linux-x64": "0.2.2",
-    "@magicblock-labs/bolt-cli-linux-arm64": "0.2.2",
-    "@magicblock-labs/bolt-cli-windows-x86": "0.2.2",
-    "@magicblock-labs/bolt-cli-windows-x64": "0.2.2"
+    "@magicblock-labs/bolt-cli-darwin-x64": "0.2.3",
+    "@magicblock-labs/bolt-cli-darwin-arm64": "0.2.3",
+    "@magicblock-labs/bolt-cli-linux-x86": "0.2.3",
+    "@magicblock-labs/bolt-cli-linux-x64": "0.2.3",
+    "@magicblock-labs/bolt-cli-linux-arm64": "0.2.3",
+    "@magicblock-labs/bolt-cli-windows-x86": "0.2.3",
+    "@magicblock-labs/bolt-cli-windows-x64": "0.2.3"
   },
   "publishConfig": {
     "access": "public"

--- a/crates/bolt-cli/npm-package/package.json.tmpl
+++ b/crates/bolt-cli/npm-package/package.json.tmpl
@@ -1,7 +1,7 @@
 {
   "name": "@magicblock-labs/${node_pkg}",
   "description": "Bolt CLI tool (${node_pkg})",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/magicblock-labs/bolt.git"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,12 +1,14 @@
 
-## [0.2.2] - 2025-02-24
+## [0.2.3] - 2025-04-25
 
 ### ✨️ Features
+ - Updating Bolt client for C# (#129)
  - Adding DestroyComponent function (#143)
  - Separating apply and apply_with_session (#141)
 
 
 ### 🐛 Bug Fixes
+ - Fixing async cli commands (#159)
 
 ## [0.2.1] - 2025-02-17
 

--- a/scripts/test-publish.sh
+++ b/scripts/test-publish.sh
@@ -1,0 +1,26 @@
+DRY_RUN="true"
+DRY_RUN_FLAG=""
+if [ "${DRY_RUN}" = "true" ]; then
+DRY_RUN_FLAG="--dry-run"
+fi
+
+if [ "${DRY_RUN}" = "true" ]; then
+NO_VERIFY_FLAG="--no-verify"
+fi      
+
+cargo +nightly publish -Zpackage-workspace $DRY_RUN_FLAG $NO_VERIFY_FLAG \
+    -p world \
+    -p bolt-cli \
+    -p bolt-lang \
+    -p bolt-utils \
+    -p bolt-system \
+    -p bolt-component \
+    -p bolt-attribute-bolt-arguments \
+    -p bolt-attribute-bolt-component \
+    -p bolt-attribute-bolt-component-deserialize \
+    -p bolt-attribute-bolt-component-id \
+    -p bolt-attribute-bolt-delegate \
+    -p bolt-attribute-bolt-extra-accounts \
+    -p bolt-attribute-bolt-program \
+    -p bolt-attribute-bolt-system \
+    -p bolt-attribute-bolt-system-input


### PR DESCRIPTION
Bolt v0.2.3

<!-- greptile_comment -->

## Greptile Summary

Coordinated version bump to 0.2.3 across the Bolt ecosystem, including Cargo workspace, TypeScript SDK, and CLI packages, with corresponding changelog updates.

- Version updated to 0.2.3 in `/Cargo.toml` workspace and all internal dependencies
- Version bumped to 0.2.3 in `/clients/typescript/package.json` for Bolt SDK
- Version updated to 0.2.3 in `/crates/bolt-cli/npm-package/package.json` and its platform-specific dependencies
- Version synchronized in `/crates/bolt-cli/npm-package/package.json.tmpl` template file



<!-- /greptile_comment -->