### PR TITLE
test validator

### DIFF
--- a/tests/test-validator.sh
+++ b/tests/test-validator.sh
@@ -22,14 +22,19 @@ solana-test-validator --reset \
 VALIDATOR_PID=$!
 
 cleanup() {
+  if ps -p $VALIDATOR_PID > /dev/null; then
     kill $VALIDATOR_PID
     wait $VALIDATOR_PID 2>/dev/null || true
+  fi
 }
 trap cleanup EXIT
 
 sleep 3
 
-solana airdrop -u http://localhost:8899 100000 ./tests/fixtures/provider.json
+if ! solana airdrop -u http://localhost:8899 100000 ./tests/fixtures/provider.json; then
+  echo "Error: Failed to airdrop SOL to provider account"
+  exit 1
+fi
 
 anchor test --skip-build --skip-deploy --skip-local-validator
 

--- a/tests/test-validator.sh
+++ b/tests/test-validator.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Starting validator"
+
+solana-test-validator --reset \
+  --bpf-program DELeGGvXpWV2fqJUhqcF5ZSYMS4JTLjteaAMARRSaeSh tests/fixtures/delegation.so \
+  --bpf-program KeyspM2ssCJbqUhQ4k7sveSiY4WjnYsrXkC8oDbwde5 tests/fixtures/session_keys.so \
+  --bpf-program WorLD15A7CrDwLcLy4fRqtaTb9fbd8o8iqiEMUDse2n target/deploy/world.so \
+  --bpf-program CmP2djJgABZ4cRokm4ndxuq6LerqpNHLBsaUv2XKEJua target/deploy/bolt_component.so \
+  --bpf-program 7X4EFsDJ5aYTcEjKzJ94rD8FRKgQeXC89fkpeTS4KaqP target/deploy/bolt_system.so \
+  --bpf-program Fn1JzzEdyb55fsyduWS94mYHizGhJZuhvjX6DVvrmGbQ target/deploy/position.so \
+  --bpf-program 6LHhFVwif6N9Po3jHtSmMVtPjF6zRfL3xMosSzcrQAS8 target/deploy/system_apply_velocity.so \
+  --bpf-program HT2YawJjkNmqWcLNfPAMvNsLdWwPvvvbKA5bpMw4eUpq target/deploy/system_fly.so \
+  --bpf-program FSa6qoJXFBR3a7ThQkTAMrC15p6NkchPEjBdd4n6dXxA target/deploy/system_simple_movement.so \
+  --bpf-program CbHEFbSQdRN4Wnoby9r16umnJ1zWbULBHg4yqzGQonU1 target/deploy/velocity.so \
+  --account EEmsg7GbxEAw5f9hGfZRmJRJ27HK8KeGDp7ViW9X2mYa tests/fixtures/commit_record.json \
+  --account 7nQvHcfEqtFmY2q6hiQbidu8BCNdqegnEFfH7HkByFn5 tests/fixtures/committed_state.json \
+  > /dev/null 2>&1 &
+
+VALIDATOR_PID=$!
+
+cleanup() {
+    kill $VALIDATOR_PID
+    wait $VALIDATOR_PID 2>/dev/null || true
+}
+trap cleanup EXIT
+
+sleep 3
+
+solana airdrop -u http://localhost:8899 100000 ./tests/fixtures/provider.json
+
+anchor test --skip-build --skip-deploy --skip-local-validator
+


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Tooling | No | [Link](<Issue link here>) |

## Problem

_What problem are you trying to solve?_

Currently cannot run tests without program deployment keypairs


## Solution

_How did you solve the problem?_

Runs tests in an ephemeral local validator with pre-loaded programs for testing

**New scripts**:

- `tests/test-validator.sh` : Runs tests in a local validator that lasts the duration of the tests.


<!-- greptile_comment -->

## Greptile Summary

Added a test validator script that initializes an ephemeral local Solana validator with pre-loaded programs and accounts for testing purposes.

- Added `/tests/test-validator.sh` to launch validator with 9 BPF programs and 2 test accounts
- Implemented cleanup trap to properly terminate validator process on script exit
- Added 100000 SOL airdrop to provider account for test transactions
- Configured validator to run silently (`> /dev/null 2>&1`) to reduce noise during tests
- Added proper error handling with `set -euo pipefail` for script robustness



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->