### PR TITLE
:white_check_mark: Fixing solana-cli install link

### DIFF
--- a/.github/workflows/publish-bolt-crates.yml
+++ b/.github/workflows/publish-bolt-crates.yml
@@ -62,7 +62,7 @@ jobs:
       - name: install solana
         if: steps.cache-solana.outputs.cache-hit != 'true'
         run: |
-          sh -c "$(curl -sSfL https://release.solana.com/${{ env.solana_version }}/install)"
+          sh -c "$(curl -sSfL https://release.anza.xyz/${{ env.solana_version }}/install)"
           export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
           solana --version
 

--- a/.github/workflows/publish-bolt-sdk.yml
+++ b/.github/workflows/publish-bolt-sdk.yml
@@ -57,7 +57,7 @@ jobs:
       - name: install solana
         if: steps.cache-solana.outputs.cache-hit != 'true'
         run: |
-          sh -c "$(curl -sSfL https://release.solana.com/${{ env.solana_version }}/install)"
+          sh -c "$(curl -sSfL https://release.anza.xyz/${{ env.solana_version }}/install)"
           export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
           solana --version
 

--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install Solana
         run: |
-          sh -c "$(curl -sSfL https://release.solana.com/${{ env.solana_version }}/install)"
+          sh -c "$(curl -sSfL https://release.anza.xyz/${{ env.solana_version }}/install)"
           export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
           solana --version

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install Solana
         run: |
-          sh -c "$(curl -sSfL https://release.solana.com/${{ env.solana_version }}/install)"
+          sh -c "$(curl -sSfL https://release.anza.xyz/${{ env.solana_version }}/install)"
           export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
           solana --version
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install Solana
         run: |
-          sh -c "$(curl -sSfL https://release.solana.com/${{ env.solana_version }}/install)"
+          sh -c "$(curl -sSfL https://release.anza.xyz/${{ env.solana_version }}/install)"
           export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
           solana --version


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Tooling | No | No |

## Problem

https://release.solana.com -> https://release.anza.xyz

<!-- greptile_comment -->

## Greptile Summary

Updates Solana CLI installation URL from release.solana.com to release.anza.xyz across all GitHub workflow files, maintaining Solana version v1.18.15.

- Changed installation URL in `.github/workflows/run-tests.yml`, `.github/workflows/publish-bolt-sdk.yml`, `.github/workflows/run-lint.yml`, and `.github/workflows/publish-bolt-crates.yml`
- Maintains consistent Solana version v1.18.15 across all workflows
- Installation process and functionality remain unchanged, only the source URL is updated



<!-- /greptile_comment -->