### PR TITLE
:memo: Adding latest nightly Rust toolchain as a requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ With Bolt, you can create games that live forever on the blockchain. These games
 | `@magicblock-labs/bolt-sdk` | TypeScript client for Anchor programs                                            | [![npm](https://img.shields.io/npm/v/@magicblock-labs/bolt-sdk.svg?color=blue)](https://www.npmjs.com/package/@magicblock-labs/bolt-sdk)         | [![Docs](https://img.shields.io/badge/docs-tutorials-blue)](https://book.boltengine.gg/getting_started/world_program.html#typescript-sdk-installation)     |
 | `@magicblock-labs/ephemeral-validator` | MagicBlock's extremely fast Solana compatible validator | [![npm](https://img.shields.io/npm/v/@magicblock-labs/ephemeral-validator.svg?color=blue)](https://www.npmjs.com/package/@magicblock-labs/ephemeral-validator) | [![Docs](https://img.shields.io/badge/docs-tutorials-blue)](https://book.boltengine.gg/getting_started/ephemeral_validator.html) |
 
+## ⚡️ Requirements
+
+Make sure to have the latest nightly toolchain, which is required to generate IDLs.
+```bash
+rustup update nightly
+```
+
 ## ⚡️ Installing the bolt-cli
 
 ```bash


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Docs | No | None |

## Problem

People with old version of nightly Rust toolchain will face this error

```rust
error[E0599]: no method named `file` found for reference `&proc_macro::Span` in the current scope
   --> /home/username/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/proc-macro2-1.0.95/src/wrapper.rs:465:36
    |
465 |             Span::Compiler(s) => s.file(),
    |                                    ^^^^ method not found in `&Span`error[E0599]: no method named `local_file` found for reference `&proc_macro::Span` in the current scope
   --> /home/username/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/proc-macro2-1.0.95/src/wrapper.rs:473:36
    |
473 |             Span::Compiler(s) => s.local_file(),
    |                                    ^^^^^^^^^^ method not found in `&Span`error: could not compile `proc-macro2` (lib) due to 2 previous errors
Error: Building IDL failed
```

## Solution

Run `rustup update nightly`
