### PR TITLE
:white_check_mark: Adding clippy as a toolchain component

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.86.0"
-components = ["rustfmt"]
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Tooling | No | None |

## Problem

clippy not installed on ci

## Solution

Manually installing it

<!-- greptile_comment -->

## Greptile Summary

Adds clippy component installation to the Bolt crates publishing workflow, ensuring proper linting capabilities in CI.

- Modified `.github/workflows/publish-bolt-crates.yml` to explicitly install clippy with Rust toolchain installation
- Ensures consistent linting checks during the CI publishing process



<!-- /greptile_comment -->