### PR TITLE
:arrow_up: Updating ephemeral-validator

### DIFF
--- a/crates/bolt-cli/src/templates/ephemeral-validator.toml
+++ b/crates/bolt-cli/src/templates/ephemeral-validator.toml
@@ -2,7 +2,6 @@
 remote = "http://localhost:8899"
 lifecycle = "ephemeral"
 commit = { frequency_millis = 50_000 }
-payer = { init_sol = 1_000 }
 
 [rpc]
 addr = "0.0.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,9 @@
     "packages": {
         "": {
             "license": "MIT",
+            "dependencies": {
+                "@magicblock-labs/ephemeral-validator": "^0.1.7"
+            },
             "devDependencies": {
                 "@metaplex-foundation/beet": "^0.7.1",
                 "@metaplex-foundation/beet-solana": "^0.4.0",
@@ -30,6 +33,87 @@
             "engines": {
                 "node": ">=6.9.0"
             }
+        },
+        "node_modules/@magicblock-labs/ephemeral-validator": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/@magicblock-labs/ephemeral-validator/-/ephemeral-validator-0.1.7.tgz",
+            "integrity": "sha512-g/3tnQ3tfspP3XIt/k8kmJzNGdwFx9QUXfJtNuSjIp4VMkaD32swRQLN6Ku2juUlJ9xeVii/MRSAjNsqORff8w==",
+            "license": "Business Source License 1.1",
+            "bin": {
+                "ephemeral-validator": "ephemeralValidator.js"
+            },
+            "optionalDependencies": {
+                "@magicblock-labs/ephemeral-validator-darwin-arm64": "0.1.7",
+                "@magicblock-labs/ephemeral-validator-darwin-x64": "0.1.7",
+                "@magicblock-labs/ephemeral-validator-linux-arm64": "0.1.7",
+                "@magicblock-labs/ephemeral-validator-linux-x64": "0.1.7",
+                "@magicblock-labs/ephemeral-validator-windows-x64": "0.1.7"
+            }
+        },
+        "node_modules/@magicblock-labs/ephemeral-validator-darwin-arm64": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/@magicblock-labs/ephemeral-validator-darwin-arm64/-/ephemeral-validator-darwin-arm64-0.1.7.tgz",
+            "integrity": "sha512-UAB+dpHnNX4zXCiPn6VxC4kSpgRYW5qMQB1ye8ZTxf9ala3KMsq8OcXRJt6giKRSY0YfLVDvPWgX7ZssK7ExXA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Business Source License 1.1",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@magicblock-labs/ephemeral-validator-darwin-x64": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/@magicblock-labs/ephemeral-validator-darwin-x64/-/ephemeral-validator-darwin-x64-0.1.7.tgz",
+            "integrity": "sha512-W+lBkhEEtO9+tYqxehB7TKmmOlT+iM0drskaaZv9VLK98k+iIx/jj4pru1y6Y7VWtuGEdydbNkskRmSr8XmTTw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Business Source License 1.1",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@magicblock-labs/ephemeral-validator-linux-arm64": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/@magicblock-labs/ephemeral-validator-linux-arm64/-/ephemeral-validator-linux-arm64-0.1.7.tgz",
+            "integrity": "sha512-Z9aRo03z6ezhfqDKHkGhhvKBghpzBeiSCsO6dv05MgpZy71HF802gJqdS2r8qS0h8k67B44u1OlpAXE9tv7eqw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Business Source License 1.1",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@magicblock-labs/ephemeral-validator-linux-x64": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/@magicblock-labs/ephemeral-validator-linux-x64/-/ephemeral-validator-linux-x64-0.1.7.tgz",
+            "integrity": "sha512-yeytU6KIjTD8IB8IyuBlyYzKumpjqQpz4BlSuFiN76udXsUXuctzpG7f2VJF23MqSnr7bmSzIbqEiwN6mHO1GA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Business Source License 1.1",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@magicblock-labs/ephemeral-validator-windows-x64": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/@magicblock-labs/ephemeral-validator-windows-x64/-/ephemeral-validator-windows-x64-0.1.7.tgz",
+            "integrity": "sha512-ejHhWMy5/lTH8dVpUBAB1frRqkYptGHPu5S0qag4EnM7qrYv/ysWzT+NwRbn2WG4BT9D0UBg5gkY0OP5gk9w1A==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Business Source License 1.1",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
         },
         "node_modules/@metaplex-foundation/beet": {
             "version": "0.7.2",

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
         "typescript": "^4.3.5"
     },
     "license": "MIT",
-    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
+    "dependencies": {
+        "@magicblock-labs/ephemeral-validator": "^0.1.7"
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,41 +9,21 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@magicblock-labs/ephemeral-validator-darwin-arm64@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@magicblock-labs/ephemeral-validator-darwin-arm64/-/ephemeral-validator-darwin-arm64-0.1.0.tgz#1ef3bf1388d34cdd184ed05a9d059a7959de7e4b"
-  integrity sha512-LFezO9sWfVHWhJ5FggAw1UXoPo9wReDxIsXfs6H0lioM+dsjhib6XZMBQJ/BIAnjuImQ1ZKlAJcqt5uJjCGPDw==
+"@magicblock-labs/ephemeral-validator-linux-x64@0.1.7":
+  version "0.1.7"
+  resolved "https://registry.npmjs.org/@magicblock-labs/ephemeral-validator-linux-x64/-/ephemeral-validator-linux-x64-0.1.7.tgz"
+  integrity sha512-yeytU6KIjTD8IB8IyuBlyYzKumpjqQpz4BlSuFiN76udXsUXuctzpG7f2VJF23MqSnr7bmSzIbqEiwN6mHO1GA==
 
-"@magicblock-labs/ephemeral-validator-darwin-x64@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@magicblock-labs/ephemeral-validator-darwin-x64/-/ephemeral-validator-darwin-x64-0.1.0.tgz#be97cef596cc38dac2344811e8ee28ac75a49417"
-  integrity sha512-glyVSgZu5YW7X1QxSayTTy1wKO5mc2SgAG5tTsfuCVfKJ77UVNovCb/I1PH8Q6dGXLYJ2YE6Dn2vhpBqaW85aw==
-
-"@magicblock-labs/ephemeral-validator-linux-arm64@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@magicblock-labs/ephemeral-validator-linux-arm64/-/ephemeral-validator-linux-arm64-0.1.0.tgz#c8dd28623384b3644f28003bf2ed0a8401fc020e"
-  integrity sha512-BHk1FbvMtJQLK45d9jVIhdfc1Ho+9CB15IETRZskINnE+dtsd22yWRBYGopXnDRTxhrN62k5Qr9JmUqw/D0SGQ==
-
-"@magicblock-labs/ephemeral-validator-linux-x64@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@magicblock-labs/ephemeral-validator-linux-x64/-/ephemeral-validator-linux-x64-0.1.0.tgz#35a543743d9c08c280a9d89fe1d11392feaff066"
-  integrity sha512-sF2iKAySeCUGtvwmnuGabK9K3EeNctFitJjSMUWwgQRogfd1RoEHQLXy+pJX95Z90ShYNnOsoU9x8FrElAWHPQ==
-
-"@magicblock-labs/ephemeral-validator-windows-x64@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@magicblock-labs/ephemeral-validator-windows-x64/-/ephemeral-validator-windows-x64-0.1.0.tgz#71266dc5c1d08787597ecb1f5e213ffb8e8c809f"
-  integrity sha512-8P/4lhVLKYL4yuz1sROan2rlQIiux+4jcw4d+++CYwwyUhHrPdNUdPQXwSo4/Xcf4+D+FUSGVyb4aZbGb0dlPQ==
-
-"@magicblock-labs/ephemeral-validator@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@magicblock-labs/ephemeral-validator/-/ephemeral-validator-0.1.0.tgz#69d5561eaedcd38c44bbc32631c790b1e5a6d9f8"
-  integrity sha512-J9/hIGs/K8kCVSTJCApTJC/z+L1pTLA1hXpXqY+XXf2dfHzoUJg4j2XyyAv68dxQSFP1u++CrLNX+cdVJo1OIg==
+"@magicblock-labs/ephemeral-validator@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.npmjs.org/@magicblock-labs/ephemeral-validator/-/ephemeral-validator-0.1.7.tgz"
+  integrity sha512-g/3tnQ3tfspP3XIt/k8kmJzNGdwFx9QUXfJtNuSjIp4VMkaD32swRQLN6Ku2juUlJ9xeVii/MRSAjNsqORff8w==
   optionalDependencies:
-    "@magicblock-labs/ephemeral-validator-darwin-arm64" "^0.1.0"
-    "@magicblock-labs/ephemeral-validator-darwin-x64" "0.1.0"
-    "@magicblock-labs/ephemeral-validator-linux-arm64" "0.1.0"
-    "@magicblock-labs/ephemeral-validator-linux-x64" "0.1.0"
-    "@magicblock-labs/ephemeral-validator-windows-x64" "0.1.0"
+    "@magicblock-labs/ephemeral-validator-darwin-arm64" "0.1.7"
+    "@magicblock-labs/ephemeral-validator-darwin-x64" "0.1.7"
+    "@magicblock-labs/ephemeral-validator-linux-arm64" "0.1.7"
+    "@magicblock-labs/ephemeral-validator-linux-x64" "0.1.7"
+    "@magicblock-labs/ephemeral-validator-windows-x64" "0.1.7"
 
 "@metaplex-foundation/beet-solana@^0.4.0":
   version "0.4.1"
@@ -55,7 +35,7 @@
     bs58 "^5.0.0"
     debug "^4.3.4"
 
-"@metaplex-foundation/beet@>=0.1.0", "@metaplex-foundation/beet@^0.7.1":
+"@metaplex-foundation/beet@^0.7.1", "@metaplex-foundation/beet@>=0.1.0":
   version "0.7.2"
   resolved "https://registry.npmjs.org/@metaplex-foundation/beet/-/beet-0.7.2.tgz"
   integrity sha512-K+g3WhyFxKPc0xIvcIjNyV1eaTVJTiuaHZpig7Xx0MuYRMoJLLvhLTnUXhFdR5Tu2l2QSyKwfyXDgZlzhULqFg==
@@ -72,7 +52,7 @@
   dependencies:
     "@noble/hashes" "1.5.0"
 
-"@noble/hashes@1.5.0", "@noble/hashes@^1.4.0":
+"@noble/hashes@^1.4.0", "@noble/hashes@1.5.0":
   version "1.5.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz"
   integrity sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==
@@ -176,14 +156,6 @@
   version "1.1.2"
   resolved "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
-
-JSONStream@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz"
-  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
-  dependencies:
-    jsonparse "^1.2.0"
-    through ">=2.2.7 <3"
 
 agentkeepalive@^4.5.0:
   version "4.5.0"
@@ -347,7 +319,7 @@ buffer-from@^1.0.0, buffer-from@^1.1.0:
   resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-buffer@6.0.3, buffer@^6.0.3, buffer@~6.0.3:
+buffer@^6.0.3, buffer@~6.0.3, buffer@6.0.3:
   version "6.0.3"
   resolved "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz"
   integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
@@ -450,17 +422,17 @@ concat-map@0.0.1:
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-debug@4.3.3:
-  version "4.3.3"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz"
-  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
-  dependencies:
-    ms "2.1.2"
-
 debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
+debug@4.3.3:
+  version "4.3.3"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
   dependencies:
     ms "2.1.2"
 
@@ -499,15 +471,15 @@ delay@^5.0.0:
   resolved "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz"
   integrity sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==
 
-diff@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz"
-  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
-
 diff@^3.1.0:
   version "3.5.0"
   resolved "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
+diff@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz"
+  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -587,11 +559,6 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
-
-fsevents@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"
@@ -710,7 +677,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3:
+inherits@^2.0.3, inherits@2:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -807,13 +774,13 @@ jayson@^4.1.1:
     "@types/connect" "^3.4.33"
     "@types/node" "^12.12.54"
     "@types/ws" "^7.4.4"
-    JSONStream "^1.3.5"
     commander "^2.20.3"
     delay "^5.0.0"
     es6-promisify "^5.0.0"
     eyes "^0.1.8"
     isomorphic-ws "^4.0.1"
     json-stringify-safe "^5.0.1"
+    JSONStream "^1.3.5"
     uuid "^8.3.2"
     ws "^7.5.10"
 
@@ -840,6 +807,14 @@ jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
+
+JSONStream@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz"
+  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
+  dependencies:
+    jsonparse "^1.2.0"
+    through ">=2.2.7 <3"
 
 locate-path@^6.0.0:
   version "6.0.0"
@@ -868,17 +843,17 @@ make-error@^1.1.1:
   resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
-minimatch@4.2.1:
-  version "4.2.1"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz"
-  integrity sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==
-  dependencies:
-    brace-expansion "^1.1.7"
-
 minimatch@^3.0.4:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@4.2.1:
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz"
+  integrity sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -894,7 +869,7 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.6"
 
-mocha@^9.0.3:
+"mocha@^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X || ^9.X.X || ^10.X.X", mocha@^9.0.3:
   version "9.2.2"
   resolved "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz"
   integrity sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==
@@ -924,12 +899,17 @@ mocha@^9.0.3:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
+ms@^2.0.0:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.0.0:
+ms@2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -1131,17 +1111,17 @@ superstruct@^2.0.2:
   resolved "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz"
   integrity sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==
 
-supports-color@8.1.1:
-  version "8.1.1"
-  resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
-  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
-  dependencies:
-    has-flag "^4.0.0"
-
 supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@8.1.1:
+  version "8.1.1"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
 
@@ -1220,7 +1200,7 @@ undici-types@~5.25.1:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz"
   integrity sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==
 
-utf-8-validate@^5.0.2:
+utf-8-validate@^5.0.2, utf-8-validate@>=5.0.2:
   version "5.0.10"
   resolved "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz"
   integrity sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==
@@ -1293,7 +1273,7 @@ wrappy@1:
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@^7.5.10:
+ws@*, ws@^7.5.10:
   version "7.5.10"
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
@@ -1308,15 +1288,15 @@ y18n@^5.0.5:
   resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
-yargs-parser@20.2.4:
-  version "20.2.4"
-  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz"
-  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
-
 yargs-parser@^20.2.2:
   version "20.2.9"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+
+yargs-parser@20.2.4:
+  version "20.2.4"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz"
+  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
 yargs-unparser@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Tooling| No | None |

## Problem

toml file for ephemeral-validator has deprecated fields

## Solution

Remove them

<!-- greptile_comment -->

## Greptile Summary

Removes deprecated configuration from ephemeral validator and updates related dependencies. 

- Removed deprecated `payer` field from `crates/bolt-cli/src/templates/ephemeral-validator.toml` that was previously used for initial SOL allocation
- Added `@magicblock-labs/ephemeral-validator@0.1.7` as a production dependency in `package.json`
- Upgraded prettier to version 3.1.1 in devDependencies



<!-- /greptile_comment -->