### PR TITLE
:arrow_up: Updating ephemeral-rollups-sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,11 +955,11 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.1"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
 dependencies = [
- "borsh-derive 1.5.1",
+ "borsh-derive 1.5.7",
  "cfg_aliases 0.2.1",
 ]
 
@@ -978,16 +978,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.1"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
+checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
 dependencies = [
  "once_cell",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
- "syn_derive",
 ]
 
 [[package]]
@@ -1782,12 +1781,12 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1567ae90eac4338ad3d87228bd357b540142af5edbc333c73f06c74cd2bf336f"
+checksum = "457c3014687a59af27e1ccb46e20e6c16dc53cae5221c871a6daa64d6bfad95b"
 dependencies = [
  "anchor-lang",
- "borsh 0.10.4",
+ "borsh 1.5.7",
  "ephemeral-rollups-sdk-attribute-commit",
  "ephemeral-rollups-sdk-attribute-delegate",
  "ephemeral-rollups-sdk-attribute-ephemeral",
@@ -1796,9 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-commit"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75518f8c7369c8d704c24b79c9b6338a100531e448966ded8adc33010fb23276"
+checksum = "80fb73771b65248443528a0fd909729997a61e376b7be0104af71d8ca4fd6ba7"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1806,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-delegate"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b881281f72fe6fa8fb13b1a5402f809c09358a1032eca1a78d9987bfc99040ec"
+checksum = "503219d396b9a9e8345ee48f00cfaffa08d216ed7be6e9f754918d056a043b4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1817,9 +1816,9 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-ephemeral"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a121fb704f5a9ca695a6ef1869ccd65a2f5e1df9756ee0047a7583322517a71d"
+checksum = "c1e81a3c602c3b70605e4bd482b85f41009d467e2e4708d3293830bf03a013cd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3306,29 +3305,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4387,7 +4363,7 @@ dependencies = [
  "bitflags 2.6.0",
  "blake3",
  "borsh 0.10.4",
- "borsh 1.5.1",
+ "borsh 1.5.7",
  "bs58",
  "bv",
  "bytemuck",
@@ -4599,7 +4575,7 @@ checksum = "0317d412207639326f2393c935769d2d7429d0882d509d0dca8dc0bb55aca6a1"
 dependencies = [
  "bincode",
  "bitflags 2.6.0",
- "borsh 1.5.1",
+ "borsh 1.5.7",
  "bs58",
  "bytemuck",
  "bytemuck_derive",
@@ -4757,7 +4733,7 @@ dependencies = [
  "Inflector",
  "base64 0.22.1",
  "bincode",
- "borsh 1.5.1",
+ "borsh 1.5.7",
  "bs58",
  "lazy_static",
  "log",
@@ -4932,7 +4908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68034596cf4804880d265f834af1ff2f821ad5293e41fa0f8f59086c181fc38e"
 dependencies = [
  "assert_matches",
- "borsh 1.5.1",
+ "borsh 1.5.7",
  "num-derive 0.4.2",
  "num-traits",
  "solana-program",
@@ -4991,7 +4967,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c704c88fc457fa649ba3aabe195c79d885c3f26709efaddc453c8de352c90b87"
 dependencies = [
- "borsh 1.5.1",
+ "borsh 1.5.7",
  "bytemuck",
  "bytemuck_derive",
  "solana-program",
@@ -5096,7 +5072,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6c2318ddff97e006ed9b1291ebec0750a78547f870f62a69c56fe3b46a5d8fc"
 dependencies = [
- "borsh 1.5.1",
+ "borsh 1.5.7",
  "solana-program",
  "spl-discriminator",
  "spl-pod",
@@ -5224,18 +5200,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ anyhow = "1.0.32"
 heck = "0.5.0"
 clap = { version = "4.2.4", features = ["derive"] }
 ahash = "=0.8.11"
-ephemeral-rollups-sdk = "0.2.5"
+ephemeral-rollups-sdk = "0.2.6"
 bincode = "=1.3.3"
 which = "7.0.2"
 tokio = { version = "1", features = ["full"] }

--- a/examples/system-simple-movement/Cargo.toml
+++ b/examples/system-simple-movement/Cargo.toml
@@ -26,4 +26,4 @@ custom-panic = []
 [dependencies]
 serde.workspace = true
 bolt-lang.workspace = true
-bolt-types = { version = "0.2.2", path = "../../crates/types" }
+bolt-types = { version = "0.2.3", path = "../../crates/types" }


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | Yes | None |

Updating ephemeral-rollups-sdk to the latest version

<!-- greptile_comment -->

## Greptile Summary

This PR updates two key dependencies in the Bolt framework:

1. Updates `ephemeral-rollups-sdk` from v0.2.5 to v0.2.6 in the root `Cargo.toml`
2. Updates `bolt-types` from v0.2.2 to v0.2.3 in `examples/system-simple-movement/Cargo.toml`

These changes are part of maintaining version consistency across the codebase and keeping up with the latest improvements in the Ephemeral Rollups SDK, which is a core component providing utilities for high-throughput, low-latency transactions on Solana.

The update to `bolt-types` aligns the example with the workspace version, ensuring consistent behavior across the project. This is particularly important as the workspace configuration uses strict version pinning with the '=' operator.

## Confidence score: 4/5

1. This PR is safe to merge as it only contains version bumps of internal dependencies
2. Score of 4 given because while version updates are generally safe, the core nature of ephemeral-rollups-sdk means thorough testing is advised
3. Files needing attention:
   - `Cargo.toml` - Verify that v0.2.6 of ephemeral-rollups-sdk is stable and tested
   - `examples/system-simple-movement/Cargo.toml` - Ensure example continues to work with new bolt-types version

<sub>2 files reviewed, no comments</sub>
<sub>[Edit PR Review Bot Settings](https://app.greptile.com/review/github) | [Greptile](https://greptile.com?utm_source=greptile_expert&utm_medium=github&utm_campaign=code_reviews&utm_content=bolt_188)</sub>

<!-- /greptile_comment -->