### PR TITLE
Changelog: typo fix and macro description improvement

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -151,7 +151,7 @@ Make the CI run `yarn build` before testing
  - Upgrade to latest anchor version, supporting the new IDL s… (#33)
  - Propagate signing authority to the systems (#31)
  - Macro to define and access extra accounts  (#26)
-Inject extra account init fn with th system macro, to generate a correct idl wich contains also the extra accounts
+Inject extra account init fn with th system macro, to generate a correct idl which contains also the extra accounts
 
 ## [0.1.1] - 2024-03-09
 


### PR DESCRIPTION
**Description:**  
- Fixed a typo in the changelog ("wich" → "which")
- Improved the clarity of the extra account macro description

<!-- greptile_comment -->

## Greptile Summary

This PR makes a minor documentation improvement to the project's changelog file. The change corrects a simple spelling error in the changelog entry for version [0.2.2], changing "wich" to "which" on line 154. The affected line describes the extra accounts macro functionality: "Inject extra account init fn with th system macro, to generate a correct idl which contains also the extra accounts".

The change is purely cosmetic and affects only the `docs/CHANGELOG.md` file, which serves as a historical record of project changes across versions. This file is used by developers and users to understand what features, bug fixes, and improvements have been made in each release. The typo fix improves the professional appearance and readability of the documentation without affecting any functional code or system behavior.

## Confidence score: 5/5

• This PR is extremely safe to merge as it only fixes a spelling error in documentation
• Perfect confidence score because the change is a simple typo correction with zero risk of breaking functionality
• No files need additional attention - the change is straightforward and isolated

<!-- /greptile_comment -->