### PR TITLE
docs: fix typos

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -4,7 +4,7 @@
 
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to make participation in our project and
-our community to be a harassment-free experience for everyone, regardless of age, body
+our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
 level of experience, education, socio-economic status, nationality, personal
 appearance, race, religion, or sexual identity and orientation.

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -3,8 +3,8 @@
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
+contributors and maintainers pledge to make participation in our project and
+our community to be a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
 level of experience, education, socio-economic status, nationality, personal
 appearance, race, religion, or sexual identity and orientation.


### PR DESCRIPTION
nothing fancy, just fixed a couple of small typos in Code of Conduct doc

<!-- greptile_comment -->

## Greptile Summary

This PR makes minor grammatical corrections to the Code of Conduct document located at `docs/CODE_OF_CONDUCT.md`. The changes attempt to fix two grammatical issues in the document's language and add a newline at the end of the file for proper formatting.

The first change corrects "pledge to making" to "pledge to make" on line 6, which fixes an incorrect gerund usage. The second change adds "to be" to the sentence structure on line 7. A newline is also added at the end of the file following standard formatting conventions.

This is a documentation-only change that doesn't affect any code functionality. The Code of Conduct is an important community document that establishes behavioral standards for contributors, so maintaining clear and grammatically correct language helps ensure the community guidelines are properly communicated.

## Confidence score: 2/5

- This PR introduces a grammatical error while attempting to fix typos, making it unsafe to merge in its current state.
- The score reflects that while one fix is correct, the second change creates awkward phrasing ("pledge to make...our community to be a harassment-free experience") that should be "pledge to make...our community a harassment-free experience".
- The file `docs/CODE_OF_CONDUCT.md` needs attention to correct the grammatical issue introduced by the second change.

<!-- /greptile_comment -->