### PR TITLE
:construction_worker: Fixing C# release

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -216,6 +216,19 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Set the release version
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "RELEASE_VERSION=${{ github.event.inputs.release_version }}" >> $GITHUB_ENV
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            VERSION=$(echo "${GITHUB_REF}" | sed -E 's|refs/heads/release/v||')
+            echo "RELEASE_VERSION=${VERSION}" >> $GITHUB_ENV
+          elif [[ "${{ github.event_name }}" == "release" ]]; then
+            VERSION=$(echo "${GITHUB_REF}" | sed -E 's|refs/tags/v||')
+            echo "RELEASE_VERSION=${VERSION}" >> $GITHUB_ENV
+          fi
+
       - name: Run C# Build Script
         run: |
           cd clients/csharp


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Tooling | No | #175 |

## Problem

GH Action to release C# was creating an empty version release.

## Solution

Adding version.