### PR TITLE
:bug: Fix silent failures in C# tests

### DIFF
--- a/clients/csharp/Solana.Unity.Bolt.Test/WorldTest.cs
+++ b/clients/csharp/Solana.Unity.Bolt.Test/WorldTest.cs
@@ -31,12 +31,7 @@ namespace WorldTest {
             };
 
             TransactionInstruction instruction = WorldProgram.InitializeRegistry(initializeRegistry);
-            try {
-                await framework.SendAndConfirmInstruction(instruction);
-            } catch (Exception) {
-                // We ignore this error because it happens when the registry already exists
-            }
-
+            await framework.SendAndConfirmInstruction(instruction, mayFail: true);
         }
 
         public static async Task InitializeWorld(Framework framework) {

--- a/clients/typescript/src/generated/idl/world.json
+++ b/clients/typescript/src/generated/idl/world.json
@@ -2,7 +2,7 @@
   "address": "WorLD15A7CrDwLcLy4fRqtaTb9fbd8o8iqiEMUDse2n",
   "metadata": {
     "name": "world",
-    "version": "0.2.4",
+    "version": "0.2.6",
     "spec": "0.1.0",
     "description": "Bolt World program",
     "repository": "https://github.com/magicblock-labs/bolt"

--- a/clients/typescript/src/generated/types/world.ts
+++ b/clients/typescript/src/generated/types/world.ts
@@ -8,7 +8,7 @@ export type World = {
   address: "WorLD15A7CrDwLcLy4fRqtaTb9fbd8o8iqiEMUDse2n";
   metadata: {
     name: "world";
-    version: "0.2.4";
+    version: "0.2.6";
     spec: "0.1.0";
     description: "Bolt World program";
     repository: "https://github.com/magicblock-labs/bolt";

--- a/examples/system-simple-movement/Cargo.toml
+++ b/examples/system-simple-movement/Cargo.toml
@@ -26,4 +26,4 @@ custom-panic = []
 [dependencies]
 serde.workspace = true
 bolt-lang.workspace = true
-bolt-types = { version = "0.2.5", path = "../../crates/types" }
+bolt-types = { version = "0.2.6", path = "../../crates/types" }


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Tooling | No | None |

## Problem

C# tests would silently fail

## Solution

Check for transaction failures and panic the execution

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-06 05:16:56 UTC

<h3>Summary</h3>
This PR addresses a critical issue where C# tests were failing silently, making it impossible to detect genuine test failures. The core problem was in the `Framework.cs` file where transaction failures were being thrown as exceptions that could be caught and ignored by test frameworks, leading to false positives.

The solution introduces a more robust error handling mechanism in the C# test framework. The main change is in the `SendAndConfirmInstruction` method, which now includes an optional `mayFail` parameter that defaults to false. When a transaction fails and `mayFail` is false, instead of throwing an exception that might be silently caught, the method now forcefully exits the process with `Environment.Exit(1)` and prints a clear error message. This ensures that transaction failures cannot be ignored.

Additionally, the method now sends transactions with `skipPreflight: false` instead of `true`, enabling better validation and error detection during the preflight phase. The `WorldTest.cs` file was updated to use this new `mayFail: true` parameter for registry initialization, replacing a try-catch block that was previously hiding exceptions.

The PR also includes version bumps from 0.2.4/0.2.5 to 0.2.6 across several files, including the TypeScript generated types, world program IDL, and a Cargo.toml dependency. These version updates ensure that all components are synchronized and reflect the underlying program improvements for better error handling.
<h3>Important Files Changed</h3>

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| clients/csharp/Solana.Unity.Bolt.Test/Framework.cs | 4/5 | Core fix that replaces exception throwing with process termination for failed transactions, preventing silent failures |
| clients/csharp/Solana.Unity.Bolt.Test/WorldTest.cs | 4/5 | Removes try-catch block that was hiding exceptions and uses new `mayFail` parameter for proper error handling |
| clients/typescript/src/generated/types/world.ts | 5/5 | Version bump from 0.2.4 to 0.2.6 in generated TypeScript types to match program updates |
| clients/typescript/src/generated/idl/world.json | 5/5 | Version update from 0.2.4 to 0.2.6 in world program IDL reflecting underlying program improvements |
| examples/system-simple-movement/Cargo.toml | 4/5 | Dependency version bump from 0.2.5 to 0.2.6 to align with workspace version |

</details>
<h3>Confidence score: 4/5</h3>

- This PR effectively addresses the silent failure problem with a solid technical solution that forces test failures to be visible
- Score reflects well-implemented changes that improve test reliability, though the use of `Environment.Exit(1)` is somewhat aggressive
- Pay close attention to Framework.cs to ensure the new error handling behavior works correctly in your test environment

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Framework
    participant RpcClient
    participant SolanaBlockchain
    
    Note over User, SolanaBlockchain: C# Test Framework Transaction Handling
    
    User->>Framework: "SendAndConfirmInstruction(instruction)"
    Framework->>RpcClient: "GetLatestBlockHashAsync()"
    RpcClient-->>Framework: "Blockhash response"
    
    alt Blockhash request failed
        Framework->>Framework: "throw Exception('Failed to get latest blockhash')"
        Framework-->>User: "Exception thrown"
    end
    
    Framework->>Framework: "Build transaction with blockhash"
    Framework->>RpcClient: "SendTransactionAsync(transaction)"
    RpcClient-->>Framework: "Transaction signature"
    Framework->>RpcClient: "ConfirmTransaction(signature)"
    RpcClient-->>Framework: "Confirmation result"
    
    alt Transaction successful
        Framework-->>User: "Return signature"
    else Transaction failed and mayFail=true
        Framework-->>User: "Return null"
    else Transaction failed and mayFail=false
        Framework->>Framework: "Collect error details"
        Framework->>Framework: "Console.WriteLine(errorMessage)"
        Framework->>Framework: "Environment.Exit(1)"
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->