### PR TITLE
:arrow_up: Updating ephemeral-validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ clients/typescript/node_modules
 clients/typescript/yarn-error.log
 .yarn
 **/test-ledger
+**/test-ledger-magicblock
 
 # Examples
 tests/examples/.anchor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2695,9 +2695,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libredox"
@@ -3083,6 +3083,25 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
 
 [[package]]
 name = "object"
@@ -5859,15 +5878,15 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.33.1"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+checksum = "252800745060e7b9ffb7b2badbd8b31cfa4aa2e61af879d0a3bf2a317c20217d"
 dependencies = [
- "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
- "rayon",
+ "objc2-core-foundation",
+ "objc2-io-kit",
  "windows",
 ]
 
@@ -6680,12 +6699,24 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.57.0"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -6699,21 +6730,33 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.57.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
+ "windows-link",
  "windows-result",
- "windows-targets 0.52.6",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.57.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6722,9 +6765,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.57.0"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6732,12 +6775,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.1.2"
+name = "windows-link"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-core 0.61.2",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -6820,6 +6888,15 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ ephemeral-rollups-sdk = "^0"
 bincode = "^1"
 which = "^7"
 tokio = { version = "^1", features = ["full"] }
-sysinfo = "^0"
+sysinfo = "=0.36.1"
 bytemuck_derive = "^1"
 
 [profile.release]

--- a/crates/bolt-cli/src/templates/ephemeral-validator.toml
+++ b/crates/bolt-cli/src/templates/ephemeral-validator.toml
@@ -1,11 +1,11 @@
 [accounts]
-remote = "http://localhost:8899"
+remote.url = "http://localhost:8899"
 lifecycle = "ephemeral"
-commit = { frequency_millis = 50_000 }
+commit = { frequency-millis = 50_000 }
 
 [rpc]
 addr = "0.0.0.0"
 port = 7799
 
 [validator]
-millis_per_slot = 50
+millis-per-slot = 50


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Tooling | No | None |

## Problem

ephemeral-validator is outdated

## Solution

Update it

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-08 14:00:30 UTC

<h3>Summary</h3>
This PR updates the ephemeral-validator dependency and configuration across the Bolt framework. The main changes involve updating the ephemeral-validator configuration template to use a new schema format required by the newer version of the tool.

The most significant change is in the `ephemeral-validator.toml` template file, where the configuration format has been modernized from underscore-separated keys to hyphenated keys (`millis_per_slot` → `millis-per-slot`, `frequency_millis` → `frequency-millis`). Additionally, the remote configuration has been restructured from a simple string value to a nested object (`remote = "url"` → `remote.url = "url"`).

To support the dependency update, the `sysinfo` dependency in the root `Cargo.toml` has been pinned to an exact version (`=0.36.1`) instead of using a flexible constraint (`^0`). This ensures reproducible builds and prevents potential compatibility issues.

The `.gitignore` file has been updated to exclude new test ledger directories created by the updated ephemeral-validator, which now generates directories with the `-magicblock` suffix pattern. This change maintains consistency with existing ignore patterns for test artifacts.

These changes are part of a tooling update that doesn't affect core functionality but ensures the development environment uses the latest ephemeral-validator with its updated configuration schema.
<h3>Important Files Changed</h3>

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `.gitignore` | 5/5 | Added gitignore entry for new test ledger directories with `-magicblock` suffix |
| `Cargo.toml` | 4/5 | Pinned sysinfo dependency to exact version =0.36.1 for reproducible builds |
| `crates/bolt-cli/src/templates/ephemeral-validator.toml` | 4/5 | Updated configuration template to use new hyphenated field names and nested remote object structure |

</details>
<h3>Confidence score: 4/5</h3>

- This PR is safe to merge with minimal risk as it primarily updates tooling configuration
- Score reflects straightforward dependency and configuration updates with potential for minor compatibility issues
- Pay close attention to the ephemeral-validator template configuration changes to ensure compatibility

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->