### PR TITLE
:adhesive_bandage: Making bolt-cli buildable again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,6 +869,8 @@ dependencies = [
  "clap 4.5.22",
  "heck 0.5.0",
  "serde_json",
+ "solana-client",
+ "solana-system-interface",
  "syn 1.0.109",
  "sysinfo",
  "tokio",
@@ -5347,6 +5349,19 @@ dependencies = [
  "tokio",
  "tokio-util",
  "x509-parser",
+]
+
+[[package]]
+name = "solana-system-interface"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94d7c18cb1a91c6be5f5a8ac9276a1d7c737e39a21beba9ea710ab4b9c63bc90"
+dependencies = [
+ "js-sys",
+ "num-traits",
+ "solana-decode-error",
+ "solana-pubkey",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,10 @@ anchor-lang        = { version = "^0", features = ["init-if-needed"] }
 anchor-cli         = { version = "^0" }
 anchor-client      = { version = "^0", features = ["async"] }
 anchor-syn         = { version = "^0" }
-anchor-lang-idl = { version = "^0" }
-solana-program  = { version = "^2" }
+anchor-lang-idl    = { version = "^0" }
+solana-program = "^2"
+solana-client = "^2"
+solana-system-interface = "^1"
 zeroize = "^1.7"
 mpl-token-metadata = { version = "^5" }
 solana-security-txt = "^1"

--- a/crates/bolt-cli/Cargo.toml
+++ b/crates/bolt-cli/Cargo.toml
@@ -19,6 +19,7 @@ dev = []
 [dependencies]
 anchor-cli = { workspace = true }
 anchor-client = { workspace = true }
+solana-client = { workspace = true }
 anchor-syn = { workspace = true }
 anchor-lang-idl = { workspace = true, features = ["build"] }
 anyhow = { workspace = true }
@@ -31,3 +32,4 @@ which = { workspace = true }
 tokio = { workspace = true }
 sysinfo = { workspace = true }
 bytemuck_derive = { workspace = true }
+solana-system-interface = { workspace = true }

--- a/crates/bolt-cli/src/instructions.rs
+++ b/crates/bolt-cli/src/instructions.rs
@@ -3,10 +3,10 @@ use anchor_client::solana_sdk::commitment_config::CommitmentConfig;
 use anchor_client::solana_sdk::pubkey::Pubkey;
 use anchor_client::solana_sdk::signature::{read_keypair_file, Keypair};
 use anchor_client::solana_sdk::signer::Signer;
-use solana_system_interface::program as system_program;
 use anchor_client::Client;
-use solana_client::rpc_config::RpcSendTransactionConfig;
 use anyhow::{anyhow, Result};
+use solana_client::rpc_config::RpcSendTransactionConfig;
+use solana_system_interface::program as system_program;
 use std::rc::Rc;
 use world::{accounts, instruction, Registry, World, ID};
 

--- a/crates/bolt-cli/src/instructions.rs
+++ b/crates/bolt-cli/src/instructions.rs
@@ -1,11 +1,11 @@
 use anchor_cli::config::{Config, ConfigOverride};
-use anchor_client::solana_client::rpc_config::RpcSendTransactionConfig;
 use anchor_client::solana_sdk::commitment_config::CommitmentConfig;
 use anchor_client::solana_sdk::pubkey::Pubkey;
 use anchor_client::solana_sdk::signature::{read_keypair_file, Keypair};
 use anchor_client::solana_sdk::signer::Signer;
-use anchor_client::solana_sdk::system_program;
+use solana_system_interface::program as system_program;
 use anchor_client::Client;
+use solana_client::rpc_config::RpcSendTransactionConfig;
 use anyhow::{anyhow, Result};
 use std::rc::Rc;
 use world::{accounts, instruction, Registry, World, ID};


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Hotfix | No | None |

## Problem

`bolt-cli` was no longer buildable with Anchor >= 0.32 because it removed solang templates.

## Solution

Remove solang templates since we don't support it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Simplified CLI initialization by removing Solidity-specific options and paths.
  - Unified project creation to a single non-Solidity flow with consistent build, files, and templates.
  - Standardized test/template selection and workspace layout across languages.
  - Component-to-system dependency configuration now always applied.

- Chores
  - Added/updated Solana-related dependencies and normalized dependency declarations.
  - Minor import and formatting cleanups with no user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->